### PR TITLE
Add batching

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,7 @@
+__pycache__/
+
+external/
+
+*.sh
+
+yalis/external/checkpoints/

--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,5 @@
 __pycache__/
 
-external/
 
 *.sh
 

--- a/examples/infer.py
+++ b/examples/infer.py
@@ -18,7 +18,7 @@ if __name__ == "__main__":
         ]
 
     # Tokenizer for encoding the prompt
-    tokenizer = AutoTokenizer.from_pretrained(model_id, use_auth_token="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")
+    tokenizer = AutoTokenizer.from_pretrained(model_id)
 
     # Tokenize the input prompt
     prompt_tokens = tokenizer(prompt, return_tensors="pt").input_ids  # Remove batch dimension

--- a/examples/infer.py
+++ b/examples/infer.py
@@ -14,20 +14,20 @@ if __name__ == "__main__":
     # Input prompt for the model
     prompts = [
         "You are a helpful chatbot. Answer the following question.\nHow to bake a cake?",
-        ] * 16
+    ] * 16
 
     # Tokenizer for encoding the prompt
     tokenizer = AutoTokenizer.from_pretrained(model_id)
 
     # Tokenize the input prompt
-    prompt_tokens = tokenizer(prompts, return_tensors="pt").input_ids 
+    prompt_tokens = tokenizer(prompts, return_tensors="pt").input_ids
 
     # Number of tokens to generate
     tokens_to_gen = 256
 
     # configs
     model_config = ModelConfig(model_name=model_id, precision="bf16")
-    inference_config = InferenceConfig(batch_size = len(prompts))
+    inference_config = InferenceConfig(batch_size=len(prompts))
 
     engine = LLMEngine(model_config=model_config, inference_config=inference_config)
 
@@ -44,4 +44,3 @@ if __name__ == "__main__":
         print_rank0(f"prompt = {prompt}")
         print_rank0(f"output = {output}")
         print_rank0("==========================\n\n")
-

--- a/examples/infer.py
+++ b/examples/infer.py
@@ -14,7 +14,7 @@ if __name__ == "__main__":
     # Input prompt for the model
     prompts = [
         "You are a helpful chatbot. Answer the following question.\nHow to bake a cake?",
-        ] * 8
+        ] * 16
 
     # Tokenizer for encoding the prompt
     tokenizer = AutoTokenizer.from_pretrained(model_id)

--- a/examples/infer.py
+++ b/examples/infer.py
@@ -41,10 +41,7 @@ if __name__ == "__main__":
     # detokenized_texts = [tokenizer.decode(output_tokens_for_prompt, skip_special_tokens=True) for output_tokens_for_prompt in output_tokens]
 
     for prompt, output in zip(prompts, detokenized_text):
-        print(f"prompt = {prompt}")
-        print(f"output = {output}")
-        print("==========================\n\n")
-
-
-
+        print_rank0(f"prompt = {prompt}")
+        print_rank0(f"output = {output}")
+        print_rank0("==========================\n\n")
 

--- a/examples/infer.py
+++ b/examples/infer.py
@@ -12,28 +12,27 @@ if __name__ == "__main__":
     model_id = "meta-llama/Meta-Llama-3-8B-Instruct"
 
     # Input prompt for the model
-    prompt = [
+    prompts = [
         "You are a helpful chatbot. Answer the following question.\nHow to bake a cake?",
-        "You are a helpful chatbot. Answer the following question.\nHow to bake a cake?"
-        ]
+        ] * 8
 
     # Tokenizer for encoding the prompt
     tokenizer = AutoTokenizer.from_pretrained(model_id)
 
     # Tokenize the input prompt
-    prompt_tokens = tokenizer(prompt, return_tensors="pt").input_ids  # Remove batch dimension
+    prompt_tokens = tokenizer(prompts, return_tensors="pt").input_ids 
 
     # Number of tokens to generate
     tokens_to_gen = 256
 
     # configs
     model_config = ModelConfig(model_name=model_id, precision="bf16")
-    inference_config = InferenceConfig(batch_size = len(prompt))
+    inference_config = InferenceConfig(batch_size = len(prompts))
 
     engine = LLMEngine(model_config=model_config, inference_config=inference_config)
 
     for _ in range(10):
-        output_tokens = engine.generate(prompt_tokens)
+        output_tokens = engine.generate(prompt_tokens, report_throughput=True)
 
     output_tokens = output_tokens.cpu()
 
@@ -41,6 +40,11 @@ if __name__ == "__main__":
     detokenized_text = tokenizer.batch_decode(output_tokens, skip_special_tokens=True)
     # detokenized_texts = [tokenizer.decode(output_tokens_for_prompt, skip_special_tokens=True) for output_tokens_for_prompt in output_tokens]
 
-    print_rank0(detokenized_text)
+    for prompt, output in zip(prompts, detokenized_text):
+        print(f"prompt = {prompt}")
+        print(f"output = {output}")
+        print("==========================\n\n")
+
+
 
 

--- a/examples/infer.py
+++ b/examples/infer.py
@@ -12,20 +12,23 @@ if __name__ == "__main__":
     model_id = "meta-llama/Meta-Llama-3-8B-Instruct"
 
     # Input prompt for the model
-    prompt = "You are a helpful chatbot. Answer the following question.\nHow to bake a cake?"
+    prompt = [
+        "You are a helpful chatbot. Answer the following question.\nHow to bake a cake?",
+        "You are a helpful chatbot. Answer the following question.\nHow to bake a cake?"
+        ]
 
     # Tokenizer for encoding the prompt
-    tokenizer = AutoTokenizer.from_pretrained(model_id)
+    tokenizer = AutoTokenizer.from_pretrained(model_id, use_auth_token="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")
 
     # Tokenize the input prompt
-    prompt_tokens = tokenizer(prompt, return_tensors="pt").input_ids.squeeze(0)  # Remove batch dimension
+    prompt_tokens = tokenizer(prompt, return_tensors="pt").input_ids  # Remove batch dimension
 
     # Number of tokens to generate
     tokens_to_gen = 256
 
     # configs
     model_config = ModelConfig(model_name=model_id, precision="bf16")
-    inference_config = InferenceConfig()
+    inference_config = InferenceConfig(batch_size = len(prompt))
 
     engine = LLMEngine(model_config=model_config, inference_config=inference_config)
 
@@ -35,7 +38,9 @@ if __name__ == "__main__":
     output_tokens = output_tokens.cpu()
 
     # Decode the token IDs into text
-    detokenized_text = tokenizer.decode(output_tokens, skip_special_tokens=True)
+    detokenized_text = tokenizer.batch_decode(output_tokens, skip_special_tokens=True)
+    # detokenized_texts = [tokenizer.decode(output_tokens_for_prompt, skip_special_tokens=True) for output_tokens_for_prompt in output_tokens]
+
     print_rank0(detokenized_text)
 
 

--- a/examples/infer_speculative.py
+++ b/examples/infer_speculative.py
@@ -10,27 +10,30 @@ if __name__ == "__main__":
     target_model = yalis.model.get_model(
         target_model_id,
         fabric,
-        litgpt_checkpoint_directory=f"../yalis/external/checkpoints/{target_model_id}"
+        litgpt_checkpoint_directory=f"../yalis/external/checkpoints/{target_model_id}",
     ).cuda()
 
     draft_model_id = "meta-llama/Meta-Llama-3-8B-Instruct"
     draft_model = yalis.model.get_model(
         draft_model_id,
         fabric,
-        litgpt_checkpoint_directory=f"../yalis/external/checkpoints/{draft_model_id}"
+        litgpt_checkpoint_directory=f"../yalis/external/checkpoints/{draft_model_id}",
     ).cuda()
 
     # Initialize prompt and tokenizer
-    prompt = "You are a helpful chatbot. Answer the following question.\nHow to bake a cake?"
+    prompt = (
+        "You are a helpful chatbot. Answer the following question.\nHow to bake a cake?"
+    )
     tokenizer = AutoTokenizer.from_pretrained(target_model_id)
     tokens_to_gen = 256
     # Print the initial prompt details
     yalis.print_rank0(f"Initial prompt: '{prompt}'")
-    #print(f"Tokenized prompt (IDs): {tokens.tolist()}")
-
+    # print(f"Tokenized prompt (IDs): {tokens.tolist()}")
 
     # Initialize pipeline
-    pipeline = SpeculativeDecodingPipeline(target_model, draft_model, tokenizer, torch.bfloat16, "cuda")
+    pipeline = SpeculativeDecodingPipeline(
+        target_model, draft_model, tokenizer, torch.bfloat16, "cuda"
+    )
     pipeline.setup()
 
     pipeline.run(prompt, tokens_to_gen, 3, profile=True)

--- a/yalis/__init__.py
+++ b/yalis/__init__.py
@@ -4,9 +4,4 @@ from .utils import print_rank0
 from .engine import LLMEngine
 
 # Define the public API for the package
-__all__ = [
-    "ModelConfig",
-    "InferenceConfig",
-    "print_rank0",
-    "LLMEngine"
-]
+__all__ = ["ModelConfig", "InferenceConfig", "print_rank0", "LLMEngine"]

--- a/yalis/config.py
+++ b/yalis/config.py
@@ -1,10 +1,12 @@
 from typing import Optional, Literal
 import os
 
+
 class ModelConfig:
     """
     Configuration for model initialization and management.
     """
+
     def __init__(
         self,
         model_name: str,
@@ -19,13 +21,13 @@ class ModelConfig:
             model_path (Optional[str]): Path to custom model weights.
             precision (str): Model precision, default is 'fp16'.
         """
-        #Todo: make model_name optional. If only model_path is provided then
+        # Todo: make model_name optional. If only model_path is provided then
         # we should par
         self.model_name = model_name
-        self.model_path = model_path 
+        self.model_path = model_path
         self.precision = precision
         self._validate()
-        self.model_path = self._resolve_model_path(self.model_path) 
+        self.model_path = self._resolve_model_path(self.model_path)
 
     def _resolve_model_path(self, model_path: Optional[str]) -> str:
         """
@@ -43,7 +45,9 @@ class ModelConfig:
         if model_path is None:
             # Default to the YALIS_CACHE environment variable or a fallback directory
             cache_dir = os.getenv("YALIS_CACHE", "~/cache/yalis/")
-            model_path = os.path.join(os.path.expanduser(cache_dir), "checkpoints", self.model_name)
+            model_path = os.path.join(
+                os.path.expanduser(cache_dir), "checkpoints", self.model_name
+            )
 
         # Check if the directory exists
         if not os.path.exists(model_path):
@@ -51,7 +55,6 @@ class ModelConfig:
             raise ValueError(f"Model path does not exist: {model_path}")
 
         return model_path
- 
 
     def _validate(self):
         """
@@ -62,17 +65,22 @@ class ModelConfig:
 
         if self.precision not in {"fp32", "fp16", "bf16"}:
 
-            raise ValueError(f"Invalid precision: {self.precision}. Supported values are 'fp32', 'fp16', 'bf16'.")
+            raise ValueError(
+                f"Invalid precision: {self.precision}. Supported values are 'fp32', 'fp16', 'bf16'."
+            )
 
     def __repr__(self):
-        return (f"ModelConfig(model_name={self.model_name}, model_path={self.model_path}, "
-                f"precision={self.precision}")
+        return (
+            f"ModelConfig(model_name={self.model_name}, model_path={self.model_path}, "
+            f"precision={self.precision}"
+        )
 
 
 class InferenceConfig:
     """
     Configuration for inference parameters.
     """
+
     def __init__(
         self,
         batch_size: int = 1,
@@ -81,7 +89,7 @@ class InferenceConfig:
         temperature: Optional[float] = None,
         top_k: Optional[int] = None,
         top_p: Optional[float] = None,
-        metrics: bool = False
+        metrics: bool = False,
     ):
         """
         Initialize the inference configuration.
@@ -97,11 +105,11 @@ class InferenceConfig:
             metrics (bool): Enable real-time metrics collection.
         """
         self.batch_size = batch_size
-        #ToDo - default max_length should be none. If it is none, we should set it
-        #from the model config
+        # ToDo - default max_length should be none. If it is none, we should set it
+        # from the model config
         self.max_length = max_length
         self.decoding_strategy = decoding_strategy
-        #ToDo: support more decoding strategies - top-k, top-p, beam-search
+        # ToDo: support more decoding strategies - top-k, top-p, beam-search
         self.temperature = temperature
         self.top_k = top_k
         self.top_p = top_p
@@ -120,12 +128,20 @@ class InferenceConfig:
             raise ValueError("max_length must be a positive integer.")
 
         if self.decoding_strategy not in {"greedy"}:
-            raise ValueError(f"Invalid decoding_strategy: {self.decoding_strategy}. Supported values are 'greedy'.")
+            raise ValueError(
+                f"Invalid decoding_strategy: {self.decoding_strategy}. Supported values are 'greedy'."
+            )
 
-        if self.decoding_strategy == "beam_search" and (self.num_beams is None or self.num_beams <= 0):
-            raise ValueError("num_beams must be specified and greater than 0 for beam_search.")
+        if self.decoding_strategy == "beam_search" and (
+            self.num_beams is None or self.num_beams <= 0
+        ):
+            raise ValueError(
+                "num_beams must be specified and greater than 0 for beam_search."
+            )
 
-        if self.temperature is not None and (self.temperature <= 0.0 or self.temperature > 2.0):
+        if self.temperature is not None and (
+            self.temperature <= 0.0 or self.temperature > 2.0
+        ):
             raise ValueError("temperature must be in the range (0.0, 2.0].")
 
         if self.top_k is not None and self.top_k <= 0:
@@ -135,7 +151,8 @@ class InferenceConfig:
             raise ValueError("top_p must be in the range (0.0, 1.0].")
 
     def __repr__(self):
-        return (f"InferenceConfig(batch_size={self.batch_size}, max_length={self.max_length}, "
-                f"decoding_strategy={self.decoding_strategy}, num_beams={self.num_beams}, "
-                f"temperature={self.temperature}, top_k={self.top_k}, top_p={self.top_p}, metrics={self.metrics})")
-
+        return (
+            f"InferenceConfig(batch_size={self.batch_size}, max_length={self.max_length}, "
+            f"decoding_strategy={self.decoding_strategy}, num_beams={self.num_beams}, "
+            f"temperature={self.temperature}, top_k={self.top_k}, top_p={self.top_p}, metrics={self.metrics})"
+        )

--- a/yalis/config.py
+++ b/yalis/config.py
@@ -61,6 +61,7 @@ class ModelConfig:
             raise ValueError("Either 'model_name' or 'model_path' must be provided.")
 
         if self.precision not in {"fp32", "fp16", "bf16"}:
+
             raise ValueError(f"Invalid precision: {self.precision}. Supported values are 'fp32', 'fp16', 'bf16'.")
 
     def __repr__(self):

--- a/yalis/engine.py
+++ b/yalis/engine.py
@@ -4,6 +4,9 @@ from .config import ModelConfig, InferenceConfig
 from .model import get_model 
 from .initialize import init_distributed
 from .utils import print_rank0
+import logging
+import torch.distributed as dist
+import torch._dynamo
 
 # These flags are taken from the following URL - 
 # https://github.com/pytorch/pytorch/blob/347f96061f1cff603983b9be19ec92b374329a5b/benchmarks/gpt_fast/generate.py#L19
@@ -18,6 +21,7 @@ precision_to_dtype = {
     "fp32" : torch.float32,
 } 
 
+@torch._dynamo.disable
 @torch.no_grad()
 @torch.compile(fullgraph=True)
 def prefill(model, tokens):
@@ -31,11 +35,14 @@ def prefill(model, tokens):
     Returns:
         token_id: The next predicted token.
     """
-    input_pos = torch.arange(0, tokens.size(0), device="cuda", dtype=torch.int64)
-    logits = model(tokens.view(1, -1), input_pos)["logits"]
-    token_id = torch.argmax(logits[0, -1])
+
+    input_pos = torch.arange(0, tokens.size(1), device= "cuda", dtype=torch.int64).unsqueeze(0).repeat(tokens.size(0),1).to("cuda")
+
+    logits = model(tokens, input_pos)["logits"]
+    token_id = torch.argmax(logits[:, -1, :], dim=1).unsqueeze(1)
     return token_id
-    
+
+@torch._dynamo.disable
 @torch.no_grad()
 @torch.compile(fullgraph=True, mode="reduce-overhead")
 def generate(model, tokens, input_pos, get_probs=False):
@@ -52,8 +59,8 @@ def generate(model, tokens, input_pos, get_probs=False):
         token_id: The next predicted token.
         logits: (Optional) The raw logits from the model.
     """
-    logits = model(tokens.view(1, -1), input_pos)["logits"]
-    token_id = torch.argmax(logits[0, -1])
+    logits = model(tokens, input_pos)["logits"]
+    token_id = torch.argmax(logits[:, -1, :], dim=1).unsqueeze(1)
     if get_probs:
         return token_id, logits
     else:
@@ -113,7 +120,7 @@ class LLMEngine:
         Returns:
             output_tokens (List[Tensor]): List of generated token IDs.
         """
-        output_tokens = []
+        output_tokens = [[] for _ in range(input_tokens.size(0))]
         # Start timing the operation
         start = torch.cuda.Event(enable_timing=True)
         end = torch.cuda.Event(enable_timing=True)
@@ -121,11 +128,10 @@ class LLMEngine:
 
         with torch.no_grad(), torch.autocast(self.device, dtype=self.dtype, cache_enabled=False):
             tokens = input_tokens.clone().to(self.device)  # Move prompt tokens to the device
-
             for step in range(tokens_to_generate):
                 if step == 0:  # Prefill step
                     next_token = prefill(self.model, tokens)  # Call prefill function
-                    input_pos = torch.tensor([tokens.size(0)], device=self.device, dtype=torch.int64)
+                    input_pos = torch.tensor([tokens.size(1)], device=self.device, dtype=torch.int64).repeat(tokens.size(0), 1)
                     tokens = next_token.clone()
                 else:  # Generation step
                     with torch.nn.attention.sdpa_kernel(torch.nn.attention.SDPBackend.MATH):
@@ -134,7 +140,8 @@ class LLMEngine:
                         tokens.copy_(next_token)  # Copy the new token into tokens
 
                 # Append the generated token to output
-                output_tokens.append(next_token.clone())
+                for prompt_no, new_token in enumerate(next_token):
+                    output_tokens[prompt_no].append(new_token.clone())
 
         # End timing and calculate elapsed time
         end.record()

--- a/yalis/engine.py
+++ b/yalis/engine.py
@@ -1,14 +1,14 @@
 import torch
 from typing import Union, List, Optional
 from .config import ModelConfig, InferenceConfig
-from .model import get_model 
+from .model import get_model
 from .initialize import init_distributed
 from .utils import print_rank0
 import logging
 import torch.distributed as dist
 import torch._dynamo
 
-# These flags are taken from the following URL - 
+# These flags are taken from the following URL -
 # https://github.com/pytorch/pytorch/blob/347f96061f1cff603983b9be19ec92b374329a5b/benchmarks/gpt_fast/generate.py#L19
 torch._inductor.config.coordinate_descent_tuning = True
 torch._inductor.config.triton.unique_kernel_names = True
@@ -16,10 +16,11 @@ torch._inductor.config.fx_graph_cache = True  # Experimental feature to reduce c
 torch._inductor.config.assert_indirect_indexing = False
 
 precision_to_dtype = {
-    "bf16" : torch.bfloat16,
-    "fp16" : torch.float16,
-    "fp32" : torch.float32,
-} 
+    "bf16": torch.bfloat16,
+    "fp16": torch.float16,
+    "fp32": torch.float32,
+}
+
 
 @torch.no_grad()
 @torch.compile()
@@ -38,6 +39,7 @@ def prefill(model, tokens):
     logits = model(tokens)["logits"]
     token_id = torch.argmax(logits[:, -1, :], dim=1).unsqueeze(1)
     return token_id
+
 
 @torch.no_grad()
 @torch.compile(mode="reduce-overhead")
@@ -67,15 +69,16 @@ class LLMEngine:
     """
     The core engine for managing and running inference on large language models.
     """
+
     def __init__(
-        self, 
-        model_config: ModelConfig, 
+        self,
+        model_config: ModelConfig,
         inference_config: InferenceConfig,
-        device="cuda"
+        device="cuda",
     ):
         """
         Initialize the LLM Engine with model and inference configurations.
-        
+
         Args:
             model_config (ModelConfig): Configuration for model setup.
             inference_config (InferenceConfig): Configuration for inference behavior.
@@ -94,18 +97,18 @@ class LLMEngine:
         """
         print_rank0(f"Initializing model: {self.model_config.model_name}")
         print_rank0(f"Using precision: {self.model_config.precision}")
-        self.model = get_model(self.fabric, 
-                                self.model_config.model_path, 
-                                self.dtype)
-        self.model.set_kv_cache(batch_size=self.inference_config.batch_size, 
-                                device=self.device, 
-                                dtype=self.dtype)
-    
+        self.model = get_model(self.fabric, self.model_config.model_path, self.dtype)
+        self.model.set_kv_cache(
+            batch_size=self.inference_config.batch_size,
+            device=self.device,
+            dtype=self.dtype,
+        )
+
     def generate(
-        self, 
-        input_tokens: torch.Tensor, 
+        self,
+        input_tokens: torch.Tensor,
         tokens_to_generate: int = 50,
-        report_throughput: bool = False
+        report_throughput: bool = False,
     ) -> torch.Tensor:
         """
         Generates tokens from the model, starting with the provided tokenized input.
@@ -123,8 +126,12 @@ class LLMEngine:
         end = torch.cuda.Event(enable_timing=True)
         start.record()
 
-        with torch.no_grad(), torch.autocast(self.device, dtype=self.dtype, cache_enabled=False):
-            tokens = input_tokens.clone().to(self.device)  # Move prompt tokens to the device
+        with torch.no_grad(), torch.autocast(
+            self.device, dtype=self.dtype, cache_enabled=False
+        ):
+            tokens = input_tokens.clone().to(
+                self.device
+            )  # Move prompt tokens to the device
             for step in range(tokens_to_generate):
                 if step == 0:  # Prefill step
                     next_token = prefill(self.model, tokens)  # Call prefill function
@@ -144,5 +151,3 @@ class LLMEngine:
         if report_throughput and dist.get_rank() == 0:
             print(f"Throughput = {tput:.2f} tok/s")
         return output_tensor
- 
-

--- a/yalis/engine.py
+++ b/yalis/engine.py
@@ -21,7 +21,6 @@ precision_to_dtype = {
     "fp32" : torch.float32,
 } 
 
-#@torch._dynamo.disable
 @torch.no_grad()
 @torch.compile()
 def prefill(model, tokens):
@@ -40,7 +39,6 @@ def prefill(model, tokens):
     token_id = torch.argmax(logits[:, -1, :], dim=1).unsqueeze(1)
     return token_id
 
-#@torch._dynamo.disable
 @torch.no_grad()
 @torch.compile(mode="reduce-overhead")
 def generate(model, tokens, get_probs=False):

--- a/yalis/engine.py
+++ b/yalis/engine.py
@@ -147,7 +147,7 @@ class LLMEngine:
         end.record()
         torch.cuda.synchronize()  # Wait for all events to finish
         time_taken = start.elapsed_time(end) / 1000  # Time in seconds
-        tput = len(output_tokens) / time_taken
+        tput = sum([len(o) for o in output_tokens]) / time_taken
         #print(f"Generation took {time_taken:.2f} seconds.")
         print_rank0(f"Throughput = {tput:.2f} tok/s")
 

--- a/yalis/engine.py
+++ b/yalis/engine.py
@@ -23,7 +23,7 @@ precision_to_dtype = {
 
 #@torch._dynamo.disable
 @torch.no_grad()
-@torch.compile(fullgraph=True)
+@torch.compile()
 def prefill(model, tokens):
     """
     Prefill function for generating the first token.
@@ -36,16 +36,14 @@ def prefill(model, tokens):
         token_id: The next predicted token.
     """
 
-    input_pos = torch.arange(0, tokens.size(1), device= "cuda", dtype=torch.int64).unsqueeze(0).repeat(tokens.size(0),1).to("cuda")
-
-    logits = model(tokens, input_pos)["logits"]
+    logits = model(tokens)["logits"]
     token_id = torch.argmax(logits[:, -1, :], dim=1).unsqueeze(1)
     return token_id
 
 #@torch._dynamo.disable
 @torch.no_grad()
-@torch.compile(fullgraph=True, mode="reduce-overhead")
-def generate(model, tokens, input_pos, get_probs=False):
+@torch.compile(mode="reduce-overhead")
+def generate(model, tokens, get_probs=False):
     """
     Generate function for producing the next token(s).
 
@@ -59,7 +57,7 @@ def generate(model, tokens, input_pos, get_probs=False):
         token_id: The next predicted token.
         logits: (Optional) The raw logits from the model.
     """
-    logits = model(tokens, input_pos)["logits"]
+    logits = model(tokens)["logits"]
     token_id = torch.argmax(logits[:, -1, :], dim=1).unsqueeze(1)
     if get_probs:
         return token_id, logits
@@ -109,18 +107,19 @@ class LLMEngine:
         self, 
         input_tokens: torch.Tensor, 
         tokens_to_generate: int = 50,
+        report_throughput: bool = False
     ) -> torch.Tensor:
         """
         Generates tokens from the model, starting with the provided tokenized input.
 
         Args:
-            prompt_tokens (Tensor): The tokenized input to start generation.
+            input__tokens (Tensor): The tokenized input to start generation.
             tokens_to_gen (int): Number of tokens to generate after the prompt.
 
         Returns:
             output_tokens (List[Tensor]): List of generated token IDs.
         """
-        output_tokens = [[] for _ in range(input_tokens.size(0))]
+        output_tokens = []
         # Start timing the operation
         start = torch.cuda.Event(enable_timing=True)
         end = torch.cuda.Event(enable_timing=True)
@@ -131,26 +130,21 @@ class LLMEngine:
             for step in range(tokens_to_generate):
                 if step == 0:  # Prefill step
                     next_token = prefill(self.model, tokens)  # Call prefill function
-                    input_pos = torch.tensor([tokens.size(1)], device=self.device, dtype=torch.int64).repeat(tokens.size(0), 1)
                     tokens = next_token.clone()
                 else:  # Generation step
-                    with torch.nn.attention.sdpa_kernel(torch.nn.attention.SDPBackend.MATH):
-                        next_token = generate(self.model, tokens, input_pos)  # Call generate function
-                        input_pos.add_(1)  # Increment position
-                        tokens.copy_(next_token)  # Copy the new token into tokens
+                    next_token = generate(self.model, tokens)  # Call generate function
+                    tokens.copy_(next_token)  # Copy the new token into tokens
 
-                # Append the generated token to output
-                for prompt_no, new_token in enumerate(next_token):
-                    output_tokens[prompt_no].append(new_token.clone())
+                output_tokens.append(next_token.clone())
 
+        output_tensor = torch.cat(output_tokens, dim=1)
         # End timing and calculate elapsed time
         end.record()
         torch.cuda.synchronize()  # Wait for all events to finish
         time_taken = start.elapsed_time(end) / 1000  # Time in seconds
-        tput = sum([len(o) for o in output_tokens]) / time_taken
-        #print(f"Generation took {time_taken:.2f} seconds.")
-        print_rank0(f"Throughput = {tput:.2f} tok/s")
-
-        return torch.tensor(output_tokens)
+        tput = input_tokens.shape[0] * tokens_to_generate / time_taken
+        if report_throughput and dist.get_rank() == 0:
+            print(f"Throughput = {tput:.2f} tok/s")
+        return output_tensor
  
 

--- a/yalis/engine.py
+++ b/yalis/engine.py
@@ -21,7 +21,7 @@ precision_to_dtype = {
     "fp32" : torch.float32,
 } 
 
-@torch._dynamo.disable
+#@torch._dynamo.disable
 @torch.no_grad()
 @torch.compile(fullgraph=True)
 def prefill(model, tokens):
@@ -42,7 +42,7 @@ def prefill(model, tokens):
     token_id = torch.argmax(logits[:, -1, :], dim=1).unsqueeze(1)
     return token_id
 
-@torch._dynamo.disable
+#@torch._dynamo.disable
 @torch.no_grad()
 @torch.compile(fullgraph=True, mode="reduce-overhead")
 def generate(model, tokens, input_pos, get_probs=False):

--- a/yalis/external/download.py
+++ b/yalis/external/download.py
@@ -40,7 +40,10 @@ def download_from_hub(
         model_name: The existing config name to use for this repo_id. This is useful to download alternative weights of
             existing architectures.
     """
-    options = [f"{config['hf_config']['org']}/{config['hf_config']['name']}" for config in configs]
+    options = [
+        f"{config['hf_config']['org']}/{config['hf_config']['name']}"
+        for config in configs
+    ]
 
     if repo_id == "list":
         print("Please specify --repo_id <repo_id>. Available values:")
@@ -48,12 +51,14 @@ def download_from_hub(
         return
 
     if model_name is None and repo_id not in options:
-        print(f"Unsupported `repo_id`: {repo_id}."
-        "\nIf you are trying to download alternative "
-        "weights for a supported model, please specify the corresponding model via the `--model_name` option, "
-        "for example, `litgpt download NousResearch/Hermes-2-Pro-Llama-3-8B --model_name Llama-3-8B`."
-        "\nAlternatively, please choose a valid `repo_id` from the list of supported models, which can be obtained via "
-        "`litgpt download list`.")
+        print(
+            f"Unsupported `repo_id`: {repo_id}."
+            "\nIf you are trying to download alternative "
+            "weights for a supported model, please specify the corresponding model via the `--model_name` option, "
+            "for example, `litgpt download NousResearch/Hermes-2-Pro-Llama-3-8B --model_name Llama-3-8B`."
+            "\nAlternatively, please choose a valid `repo_id` from the list of supported models, which can be obtained via "
+            "`litgpt download list`."
+        )
         return
 
     from huggingface_hub import snapshot_download
@@ -102,7 +107,9 @@ def download_from_hub(
 
     if convert_checkpoint and not tokenizer_only:
         print("Converting checkpoint files to LitGPT format.")
-        convert_hf_checkpoint(checkpoint_dir=directory, dtype=dtype, model_name=model_name)
+        convert_hf_checkpoint(
+            checkpoint_dir=directory, dtype=dtype, model_name=model_name
+        )
 
 
 def convert_safetensors_file(safetensor_path: Path) -> None:
@@ -113,7 +120,9 @@ def convert_safetensors_file(safetensor_path: Path) -> None:
     try:
         result = safetensors_load(safetensor_path)
     except SafetensorError as e:
-        raise RuntimeError(f"{safetensor_path} is likely corrupted. Please try to re-download it.") from e
+        raise RuntimeError(
+            f"{safetensor_path} is likely corrupted. Please try to re-download it."
+        ) from e
     print(f"{safetensor_path} --> {bin_path}")
     torch.save(result, bin_path)
     try:
@@ -125,7 +134,9 @@ def convert_safetensors_file(safetensor_path: Path) -> None:
         )
 
 
-def find_weight_files(repo_id: str, access_token: Optional[str]) -> Tuple[List[str], List[str]]:
+def find_weight_files(
+    repo_id: str, access_token: Optional[str]
+) -> Tuple[List[str], List[str]]:
     from huggingface_hub import repo_info
     from huggingface_hub.utils import filter_repo_objects
 
@@ -133,7 +144,9 @@ def find_weight_files(repo_id: str, access_token: Optional[str]) -> Tuple[List[s
         info = repo_info(repo_id, token=access_token)
     filenames = [f.rfilename for f in info.siblings]
     bins = list(filter_repo_objects(items=filenames, allow_patterns=["*.bin*"]))
-    safetensors = list(filter_repo_objects(items=filenames, allow_patterns=["*.safetensors*"]))
+    safetensors = list(
+        filter_repo_objects(items=filenames, allow_patterns=["*.safetensors*"])
+    )
     return bins, safetensors
 
 
@@ -162,6 +175,7 @@ def gated_repo_catcher(repo_id: str, access_token: Optional[str]):
                     f" visit https://huggingface.co/{repo_id} for more information."
                 ) from None
         raise e from None
+
 
 if __name__ == "__main__":
     repo_id = sys.argv[1]

--- a/yalis/external/model.py
+++ b/yalis/external/model.py
@@ -530,7 +530,8 @@ def batched_index_select(t, dim, idx):
     res = res.view(*t.shape[:dim], -1, idx_size, *t.shape[dim + 1 :])
     # move batch dim to front, this is np.rollaxis(res, dim, 0) for tensors
     dims = [dim] + list(range(res.dim()))
-    del dims[dim + 1]
+    #del dims[dim + 1]
+    dims = dims[:dim + 1] + dims[dim + 2:]
     res = res.permute(dims)
     # unflatten batch dims
     res = res.view(*batch_shape, *res.shape[1:])

--- a/yalis/external/model.py
+++ b/yalis/external/model.py
@@ -12,6 +12,7 @@ from typing import Any, Optional, Tuple
 import torch
 import torch.nn as nn
 from typing_extensions import Self
+from flash_attn import flash_attn_with_kvcache
 
 from litgpt.config import Config
 import sys
@@ -37,8 +38,7 @@ class GPT(nn.Module):
                 ln_f=config.norm_class(config.n_embd, eps=config.norm_eps),
             )
         )
-        self.max_seq_length = self.config.block_size
-        self.mask_cache: Optional[torch.Tensor] = None
+        self.max_seq_length = self.config.block_size # rope cache is built here
 
     @property
     def max_seq_length(self) -> int:
@@ -78,41 +78,34 @@ class GPT(nn.Module):
         elif isinstance(module, nn.Embedding):
             torch.nn.init.normal_(module.weight, mean=0.0, std=0.02)
 
-    def forward(self, input_ids: torch.Tensor, input_pos: Optional[torch.Tensor] = None, attention_mask: Optional[torch.tensor] = None) -> torch.Tensor:
+    def forward(self, input_ids: torch.Tensor) -> torch.Tensor:
         #assert attention_mask is None, "litgpt model does not accept an attention mask"
         idx = input_ids
         T = idx.size(1)
         if self.max_seq_length < T:
             raise ValueError(f"Cannot forward sequence of length {T}, max seq length is only {self.max_seq_length}.")
 
-        if input_pos is not None:  # use the kv cache
-            cos = batched_index_select(self.cos, 0, input_pos)
-            sin = batched_index_select(self.sin, 0, input_pos)
-            if self.mask_cache is None:
-                raise TypeError("You need to call `gpt.set_kv_cache()`")
-            mask = batched_index_select(self.mask_cache, 2, input_pos)
-            if mask.dim() > 4:
-                # the mask cache has a batch dim of 1 in addition to the one
-                # we get if input_pos has a batch dimension
-                mask = mask.squeeze(1)
-        else:
-            cos = self.cos[:T]
-            sin = self.sin[:T]
-            mask = None
-
         x = self.transformer.wte(idx)  # token embeddings of shape (b, t, n_embd)
         if self.config.scale_embeddings:
             x = x * torch.tensor(self.config.n_embd**0.5, dtype=x.dtype)
         if self.config.tensor_parallel:
             x = Drop.apply(x, ax.comm_handle.inner_intra_layer_parallel_group)
+        
+        # flash attention wants the rope cache to be
+        # in the same dtype as the query
+        # ToDO: confirm if this is okay, or if we should do rope in fp32?
+        self.cos = self.cos.to(x.dtype)
+        self.sin = self.sin.to(x.dtype)
+        
         for block in self.transformer.h:
-            x = block(x, cos, sin, mask, input_pos)
+            x = block(x, self.cos, self.sin, self.token_counter)
         if self.config.tensor_parallel:
             x = Gather.apply(x, ax.comm_handle.inner_intra_layer_parallel_group)
         x = self.transformer.ln_f(x)
         x = self.lm_head(x)  # (b, t, vocab_size)
         if self.config.final_logit_softcapping is not None:
             x = torch.tanh(x / self.config.final_logit_softcapping) * self.config.final_logit_softcapping
+        self.token_counter.add_(T)
         return {"logits": x}
 
     @classmethod
@@ -165,7 +158,7 @@ class GPT(nn.Module):
         dtype: Optional[torch.dtype] = None,
     ) -> None:
         if rope_cache_length is None:
-            rope_cache_length = self.cos.size(-1)
+            rope_cache_length = self.cos.size(-1) * 2
 
         if max_seq_length is None:
             max_seq_length = self.max_seq_length
@@ -175,14 +168,11 @@ class GPT(nn.Module):
             block.attn.kv_cache = block.attn.build_kv_cache(
                 batch_size, max_seq_length, rope_cache_length, device, dtype,
             )
+        
+        self.token_counter = torch.zeros(batch_size, device=device, dtype=torch.int32)
 
-        if self.mask_cache is None or self.mask_cache.size(3) != max_seq_length:
-            # passing `attn_mask` to SDPA disables the flash implementation. since we only need the mask
-            # for the kv-cache support (only during inference), we only create it in that situation
-            self.mask_cache = build_mask_cache(max_seq_length, device)
 
     def clear_kv_cache(self) -> None:
-        self.mask_cache = None
         for block in self.transformer.h:
             block.attn.kv_cache = None
 
@@ -215,8 +205,7 @@ class Block(nn.Module):
         x: torch.Tensor,
         cos: torch.Tensor,
         sin: torch.Tensor,
-        mask: Optional[torch.Tensor] = None,
-        input_pos: Optional[torch.Tensor] = None,
+        token_counter: Optional[torch.Tensor] = None,
     ) -> torch.Tensor:
         """
         Non-parallel residual       Parallel residual
@@ -240,7 +229,7 @@ class Block(nn.Module):
         """
 
         x_normed = self.norm_1(x)
-        attention_output = self.attn(x_normed, cos, sin, mask, input_pos)
+        attention_output = self.attn(x_normed, cos, sin, token_counter)
         attention_output = self.post_attention_norm(attention_output)
 
         if self.config.parallel_residual:
@@ -274,6 +263,8 @@ class CausalSelfAttention(nn.Module):
             config.sliding_window_size is not None and
             block_idx % config.sliding_window_layer_placing == 0
         )
+        
+        assert not self.apply_sliding_window_attention, "Sliding window attention is not implemented yet"
 
         self.config = config
         if config.tensor_parallel:
@@ -290,8 +281,7 @@ class CausalSelfAttention(nn.Module):
         x: torch.Tensor,
         cos: torch.Tensor,
         sin: torch.Tensor,
-        mask: Optional[torch.Tensor] = None,
-        input_pos: Optional[torch.Tensor] = None,
+        token_counter: torch.Tensor
     ) -> torch.Tensor:
         B, T, C = x.size()  # batch size, sequence length, embedding dimensionality (n_embd)
 
@@ -309,43 +299,39 @@ class CausalSelfAttention(nn.Module):
         # maybe repeat k and v if for the non multi-head attention cases
         # training: flash attention requires it
         # inference: multi-query would require a full kv cache so avoid it to limit its memory usage
-        if self.config.n_query_groups != self.config.n_head and (input_pos is None or self.config.n_query_groups != 1):
+       
+        #print(q_per_kv, self.config.n_head, self.config.n_query_groups) 
+        #assert self.config.n_query_groups == self.config.n_head, "GQA not tested yet"
+        if self.config.n_query_groups != self.config.n_head:
             k = k.expand(B, self.config.n_query_groups, q_per_kv, T, self.config.head_size)
             v = v.expand(B, self.config.n_query_groups, q_per_kv, T, self.config.head_size)
 
-        q = q.reshape(B, -1, T, self.config.head_size)  # (B, nh_q, T, hs)
-        k = k.reshape(B, -1, T, self.config.head_size)  # (B, nh_k, T, hs)
-        v = v.reshape(B, -1, T, self.config.head_size)  # (B, nh_v, T, hs)
+        q = q.reshape(B, -1, T, self.config.head_size).transpose(1, 2).contiguous()  # (B, nh_q, T, hs)
+        k = k.reshape(B, -1, T, self.config.head_size).transpose(1, 2).contiguous()  # (B, nh_k, T, hs)
+        v = v.reshape(B, -1, T, self.config.head_size).transpose(1, 2).contiguous()  # (B, nh_v, T, hs)
+        
+        assert self.config.rope_n_elem == self.config.head_size, "partial rope is not supported yet"
 
-        q_roped = apply_rope(q[..., : self.config.rope_n_elem], cos, sin)
-        k_roped = apply_rope(k[..., : self.config.rope_n_elem], cos, sin)
-        q = torch.cat((q_roped, q[..., self.config.rope_n_elem :]), dim=-1)
-        k = torch.cat((k_roped, k[..., self.config.rope_n_elem :]), dim=-1)
+        #q_roped = apply_rope(q[..., : self.config.rope_n_elem], cos, sin)
+        #k_roped = apply_rope(k[..., : self.config.rope_n_elem], cos, sin)
+        #q = torch.cat((q_roped, q[..., self.config.rope_n_elem :]), dim=-1)
+        #k = torch.cat((k_roped, k[..., self.config.rope_n_elem :]), dim=-1)
 
-        if input_pos is not None:
-            if not isinstance(self.kv_cache, KVCache):
-                raise TypeError("You need to call `gpt.set_kv_cache()`")
-            k, v = self.kv_cache(input_pos, k, v)
+        k_cache, v_cache = self.kv_cache.k, self.kv_cache.v
+        #print(k_cache.shape, v_cache.shape, k.shape, v.shape)
 
         if self.apply_sliding_window_attention:
-            """
-                  Global Window              Sliding window             Sliding window
-                  attention mask      +            bias          =      attention mask
-            ┌────────────────────────┐  ┌───────────────────────┐  ┌─────────────────────────┐
-            │ True False False False │  │ True  True  True True │  │ True  False False False │
-            │ True True  False False │  │ True  True  True True │  │ True  True  False False │
-            │ True True  True  False │  │ False True  True True │  │ False True  True  False │
-            │ True True  True  True  │  │ False False True True │  │ False False True  True  │
-            └────────────────────────┘  └───────────────────────┘  └─────────────────────────┘
-            """
-            if mask is None:
-                mask = torch.ones(T, T, dtype=q.dtype, device=q.device).triu(diagonal=1)
-                mask.masked_fill_(mask.bool(), float("-inf"))
-            sliding_window_bias = torch.ones_like(mask).tril(diagonal=-self.config.sliding_window_size)
-            sliding_window_bias.masked_fill_(sliding_window_bias.bool(), float("-inf"))
-            mask += sliding_window_bias
+            raise NotImplementedError
+        
+        #y = self.scaled_dot_product_attention(q, k, v, mask)
 
-        y = self.scaled_dot_product_attention(q, k, v, mask)
+        y = flash_attn_with_kvcache(q=q, 
+                                    k_cache=k_cache, v_cache=v_cache, 
+                                    k=k, v=v, causal=(T > 1), 
+                                    cache_seqlens=token_counter, 
+                                    rotary_cos=cos, 
+                                    rotary_sin=sin,
+                                    rotary_interleaved=False)
 
         y = y.reshape(B, T, self.config.head_size * self.config.n_head)  # re-assemble all head outputs side by side
 
@@ -385,7 +371,7 @@ class CausalSelfAttention(nn.Module):
         dtype: Optional[torch.dtype] = None,
     ) -> "KVCache":
         heads = 1 if self.config.n_query_groups == 1 else self.config.n_head
-        v_shape = (batch_size, heads, max_seq_length, self.config.head_size)
+        v_shape = (batch_size, max_seq_length, heads, self.config.head_size)
         if rope_cache_length is None:
             if self.config.rotary_percentage != 1.0:
                 raise TypeError("Please pass the `rope_cache_length=gpt.cos.size(-1)` value")
@@ -393,8 +379,8 @@ class CausalSelfAttention(nn.Module):
         else:
             k_shape = (
                 batch_size,
-                heads,
                 max_seq_length,
+                heads,
                 rope_cache_length + self.config.head_size - self.config.rope_n_elem,
             )
         return KVCache(k_shape, v_shape, device=device, dtype=dtype)
@@ -515,7 +501,7 @@ def build_rope_cache(
     seq_idx = torch.arange(seq_len, device=device) / condense_ratio
 
     # Calculate the product of position index and $\theta_i$
-    idx_theta = torch.outer(seq_idx, theta).repeat(1, 2)
+    idx_theta = torch.outer(seq_idx, theta) #.repeat(1, 2) repeat is not needed for flash attention
 
     return torch.cos(idx_theta), torch.sin(idx_theta)
 
@@ -523,6 +509,7 @@ def batched_index_select(t, dim, idx):
     """index_select for batched index and unbatched t"""
     if idx.dim() == 1:
         return torch.index_select(t, dim, idx)
+
 
     *batch_shape, idx_size = idx.shape
     res = torch.index_select(t, dim, idx.reshape(-1))  # flat index
@@ -583,7 +570,12 @@ def batched_index_copy_(t, dim, idx, val):
         # fall back to for loop
         for i in range(batch_size):
             unbatched_dim = dim if dim < 0 else dim - 1
-            t[i].index_copy_(unbatched_dim, idx[i], val[i])
+            #print(idx[i])
+            #print(t.shape, val.shape, unbatched_dim)
+            #exit()
+            t[i].index_copy_(unbatched_dim, 
+                            idx[i], 
+                            val[i])
         return t
 
 
@@ -621,18 +613,41 @@ class KVCache(nn.Module):
         self.v = self.v.to(v.dtype)
         # update the cache
         n = k.size(0)
-        k = batched_index_copy_(self.k[:n, ...], -2, input_pos, k)
-        v = batched_index_copy_(self.v[:n, ...], -2, input_pos, v)
-        return k, v
+        #k = batched_index_copy_(self.k[:n, ...], -2, input_pos, k)
+        #v = batched_index_copy_(self.v[:n, ...], -2, input_pos, v)
+        if input_pos.size(1) > 1:
+            # prefill phase
+            sequence_length = k.shape[2]
+            self.k[:, :, :sequence_length, :] = k[:, :, :sequence_length, :]
+            self.v[:, :, :sequence_length, :] = v[:, :, :sequence_length, :]
+            #print(k.shape, self.k.shape)
+            #self.k.narrow(dim=2, start=0, length=sequence_length).copy_(k)
+            #self.v.narrow(dim=2, start=0, length=sequence_length).copy_(v)
+            #print(sequence_length)
+            #for i in range(n):
+            #    self.k[i, :, :sequence_length, :] = k[i]
+            #    self.v[i, :, :sequence_length, :] = v[i]
+            #    index = torch.arange(sequence_length, device="cuda")
+            #    self.k[i].index_copy_(-2, index, k[i])
+            #    self.v[i].index_copy_(-2, index, v[i])
+            #exit()
+
+            #print(input_pos.shape, k.shape, self.k.shape)
+            #exit()
+            #batched_index_copy_(self.k[:n, ...], -2, input_pos, k)
+            #batched_index_copy_(self.v[:n, ...], -2, input_pos, v)
+        else:
+            # generate phase
+            #self.k[:n, :, input_pos, :].copy_(k)
+            #self.v[:n, :, input_pos, :].copy_(v)
+            batched_index_copy_(self.k[:n, ...], -2, input_pos, k)
+            batched_index_copy_(self.v[:n, ...], -2, input_pos, v)
+        return self.k[:n], self.v[:n]
 
     def reset_parameters(self) -> None:
         torch.nn.init.zeros_(self.k)
         torch.nn.init.zeros_(self.v)
 
-
-def build_mask_cache(max_seq_length: int, device: Optional[torch.device] = None) -> torch.Tensor:
-    ones = torch.ones((max_seq_length, max_seq_length), device=device, dtype=torch.bool)
-    return torch.tril(ones).unsqueeze(0).unsqueeze(0)
 
 
 class RMSNorm(torch.nn.Module):

--- a/yalis/external/model.py
+++ b/yalis/external/model.py
@@ -291,10 +291,10 @@ class CausalSelfAttention(nn.Module):
         q_per_kv = self.config.n_head // self.config.n_query_groups
         total_qkv = q_per_kv + 2  # each group has 1+ queries, 1 key, and 1 value
         qkv = qkv.view(B, T, self.config.n_query_groups, total_qkv, self.config.head_size)
-        qkv = qkv.permute(0, 2, 3, 1, 4)  # (B, n_query_groups, total_qkv, T, hs)
+        #qkv = qkv.permute(0, 2, 3, 1, 4)  # (B, n_query_groups, total_qkv, T, hs)
 
         # split batched computation into three
-        q, k, v = qkv.split((q_per_kv, 1, 1), dim=2)
+        q, k, v = qkv.split((q_per_kv, 1, 1), dim=3)
 
         # maybe repeat k and v if for the non multi-head attention cases
         # training: flash attention requires it
@@ -302,13 +302,13 @@ class CausalSelfAttention(nn.Module):
        
         #print(q_per_kv, self.config.n_head, self.config.n_query_groups) 
         #assert self.config.n_query_groups == self.config.n_head, "GQA not tested yet"
-        if self.config.n_query_groups != self.config.n_head:
-            k = k.expand(B, self.config.n_query_groups, q_per_kv, T, self.config.head_size)
-            v = v.expand(B, self.config.n_query_groups, q_per_kv, T, self.config.head_size)
+        #if self.config.n_query_groups != self.config.n_head:
+        #    k = k.expand(B, self.config.n_query_groups, q_per_kv, T, self.config.head_size)
+        #    v = v.expand(B, self.config.n_query_groups, q_per_kv, T, self.config.head_size)
 
-        q = q.reshape(B, -1, T, self.config.head_size).transpose(1, 2).contiguous()  # (B, nh_q, T, hs)
-        k = k.reshape(B, -1, T, self.config.head_size).transpose(1, 2).contiguous()  # (B, nh_k, T, hs)
-        v = v.reshape(B, -1, T, self.config.head_size).transpose(1, 2).contiguous()  # (B, nh_v, T, hs)
+        q = q.reshape(B, T, -1, self.config.head_size).contiguous()  # (B, T, nh_q, hs)
+        k = k.reshape(B, T, -1, self.config.head_size).contiguous()  # (B, T, nh_k, hs)
+        v = v.reshape(B, T, -1, self.config.head_size).contiguous()  # (B, T, nh_v, hs)
         
         assert self.config.rope_n_elem == self.config.head_size, "partial rope is not supported yet"
 
@@ -318,7 +318,6 @@ class CausalSelfAttention(nn.Module):
         #k = torch.cat((k_roped, k[..., self.config.rope_n_elem :]), dim=-1)
 
         k_cache, v_cache = self.kv_cache.k, self.kv_cache.v
-        #print(k_cache.shape, v_cache.shape, k.shape, v.shape)
 
         if self.apply_sliding_window_attention:
             raise NotImplementedError
@@ -370,7 +369,8 @@ class CausalSelfAttention(nn.Module):
         device: Optional[torch.device] = None,
         dtype: Optional[torch.dtype] = None,
     ) -> "KVCache":
-        heads = 1 if self.config.n_query_groups == 1 else self.config.n_head
+        
+        heads = self.config.n_query_groups
         v_shape = (batch_size, max_seq_length, heads, self.config.head_size)
         if rope_cache_length is None:
             if self.config.rotary_percentage != 1.0:
@@ -570,9 +570,6 @@ def batched_index_copy_(t, dim, idx, val):
         # fall back to for loop
         for i in range(batch_size):
             unbatched_dim = dim if dim < 0 else dim - 1
-            #print(idx[i])
-            #print(t.shape, val.shape, unbatched_dim)
-            #exit()
             t[i].index_copy_(unbatched_dim, 
                             idx[i], 
                             val[i])
@@ -620,26 +617,7 @@ class KVCache(nn.Module):
             sequence_length = k.shape[2]
             self.k[:, :, :sequence_length, :] = k[:, :, :sequence_length, :]
             self.v[:, :, :sequence_length, :] = v[:, :, :sequence_length, :]
-            #print(k.shape, self.k.shape)
-            #self.k.narrow(dim=2, start=0, length=sequence_length).copy_(k)
-            #self.v.narrow(dim=2, start=0, length=sequence_length).copy_(v)
-            #print(sequence_length)
-            #for i in range(n):
-            #    self.k[i, :, :sequence_length, :] = k[i]
-            #    self.v[i, :, :sequence_length, :] = v[i]
-            #    index = torch.arange(sequence_length, device="cuda")
-            #    self.k[i].index_copy_(-2, index, k[i])
-            #    self.v[i].index_copy_(-2, index, v[i])
-            #exit()
-
-            #print(input_pos.shape, k.shape, self.k.shape)
-            #exit()
-            #batched_index_copy_(self.k[:n, ...], -2, input_pos, k)
-            #batched_index_copy_(self.v[:n, ...], -2, input_pos, v)
         else:
-            # generate phase
-            #self.k[:n, :, input_pos, :].copy_(k)
-            #self.v[:n, :, input_pos, :].copy_(v)
             batched_index_copy_(self.k[:n, ...], -2, input_pos, k)
             batched_index_copy_(self.v[:n, ...], -2, input_pos, v)
         return self.k[:n], self.v[:n]

--- a/yalis/external/model.py
+++ b/yalis/external/model.py
@@ -25,20 +25,24 @@ from axonn.intra_layer.communication import Drop, Gather
 
 
 class GPT(nn.Module):
-    def __init__(self, config: Config)-> None:
+    def __init__(self, config: Config) -> None:
         super().__init__()
         assert config.padded_vocab_size is not None
         self.config = config
 
-        self.lm_head = nn.Linear(config.n_embd, config.padded_vocab_size, bias=config.lm_head_bias)
+        self.lm_head = nn.Linear(
+            config.n_embd, config.padded_vocab_size, bias=config.lm_head_bias
+        )
         self.transformer = nn.ModuleDict(
             dict(
                 wte=nn.Embedding(config.padded_vocab_size, config.n_embd),
-                h=nn.ModuleList(Block(config, block_idx) for block_idx in range(config.n_layer)),
+                h=nn.ModuleList(
+                    Block(config, block_idx) for block_idx in range(config.n_layer)
+                ),
                 ln_f=config.norm_class(config.n_embd, eps=config.norm_eps),
             )
         )
-        self.max_seq_length = self.config.block_size # rope cache is built here
+        self.max_seq_length = self.config.block_size  # rope cache is built here
 
     @property
     def max_seq_length(self) -> int:
@@ -51,8 +55,10 @@ class GPT(nn.Module):
         This allows setting a smaller number to avoid allocating unused memory
         """
         if value > self.config.block_size:
-            raise ValueError(f"Cannot attend to {value}, block size is only {self.config.block_size}."
-                             " This is likely because the input text exceeds the supported context length of this model.")
+            raise ValueError(
+                f"Cannot attend to {value}, block size is only {self.config.block_size}."
+                " This is likely because the input text exceeds the supported context length of this model."
+            )
         self._max_seq_length = value
         if not hasattr(self, "cos"):
             # first call
@@ -79,24 +85,26 @@ class GPT(nn.Module):
             torch.nn.init.normal_(module.weight, mean=0.0, std=0.02)
 
     def forward(self, input_ids: torch.Tensor) -> torch.Tensor:
-        #assert attention_mask is None, "litgpt model does not accept an attention mask"
+        # assert attention_mask is None, "litgpt model does not accept an attention mask"
         idx = input_ids
         T = idx.size(1)
         if self.max_seq_length < T:
-            raise ValueError(f"Cannot forward sequence of length {T}, max seq length is only {self.max_seq_length}.")
+            raise ValueError(
+                f"Cannot forward sequence of length {T}, max seq length is only {self.max_seq_length}."
+            )
 
         x = self.transformer.wte(idx)  # token embeddings of shape (b, t, n_embd)
         if self.config.scale_embeddings:
             x = x * torch.tensor(self.config.n_embd**0.5, dtype=x.dtype)
         if self.config.tensor_parallel:
             x = Drop.apply(x, ax.comm_handle.inner_intra_layer_parallel_group)
-        
+
         # flash attention wants the rope cache to be
         # in the same dtype as the query
         # ToDO: confirm if this is okay, or if we should do rope in fp32?
         self.cos = self.cos.to(x.dtype)
         self.sin = self.sin.to(x.dtype)
-        
+
         for block in self.transformer.h:
             x = block(x, self.cos, self.sin, self.token_counter)
         if self.config.tensor_parallel:
@@ -104,7 +112,10 @@ class GPT(nn.Module):
         x = self.transformer.ln_f(x)
         x = self.lm_head(x)  # (b, t, vocab_size)
         if self.config.final_logit_softcapping is not None:
-            x = torch.tanh(x / self.config.final_logit_softcapping) * self.config.final_logit_softcapping
+            x = (
+                torch.tanh(x / self.config.final_logit_softcapping)
+                * self.config.final_logit_softcapping
+            )
         self.token_counter.add_(T)
         return {"logits": x}
 
@@ -112,14 +123,24 @@ class GPT(nn.Module):
     def from_name(cls, name: str, **kwargs: Any) -> Self:
         return cls(Config.from_name(name, **kwargs))
 
-    def rope_cache(self, device: Optional[torch.device] = None) -> Tuple[torch.Tensor, torch.Tensor]:
+    def rope_cache(
+        self, device: Optional[torch.device] = None
+    ) -> Tuple[torch.Tensor, torch.Tensor]:
 
         if self.config.rope_adjustments is None:
             extra_config = None
 
         else:
-            adjusted_params_required = ["factor", "low_freq_factor", "high_freq_factor", "original_max_seq_len"]
-            params_present = [param in self.config.rope_adjustments for param in adjusted_params_required]
+            adjusted_params_required = [
+                "factor",
+                "low_freq_factor",
+                "high_freq_factor",
+                "original_max_seq_len",
+            ]
+            params_present = [
+                param in self.config.rope_adjustments
+                for param in adjusted_params_required
+            ]
             num_params_present = sum(params_present)
 
             if num_params_present == 0:
@@ -127,14 +148,22 @@ class GPT(nn.Module):
             elif num_params_present == 4:
                 # These parameters should always be used together so that we don't interfere with standard rope
                 extra_config = {
-                    "original_max_seq_len": self.config.rope_adjustments["original_max_seq_len"],
+                    "original_max_seq_len": self.config.rope_adjustments[
+                        "original_max_seq_len"
+                    ],
                     "factor": self.config.rope_adjustments["factor"],
                     "low_freq_factor": self.config.rope_adjustments["low_freq_factor"],
-                    "high_freq_factor": self.config.rope_adjustments["high_freq_factor"],
+                    "high_freq_factor": self.config.rope_adjustments[
+                        "high_freq_factor"
+                    ],
                 }
             else:
                 # Some but not all parameters are specified; raise an error
-                missing_params = [param for param, present in zip(adjusted_params_required, params_present) if not present]
+                missing_params = [
+                    param
+                    for param, present in zip(adjusted_params_required, params_present)
+                    if not present
+                ]
                 raise ValueError(
                     f"The following adjusted RoPE parameters are missing in rope_adjustments: {', '.join(missing_params)}. "
                     "All adjusted RoPE parameters must be specified together."
@@ -166,11 +195,14 @@ class GPT(nn.Module):
         # initialize the kv cache for all blocks
         for block in self.transformer.h:
             block.attn.kv_cache = block.attn.build_kv_cache(
-                batch_size, max_seq_length, rope_cache_length, device, dtype,
+                batch_size,
+                max_seq_length,
+                rope_cache_length,
+                device,
+                dtype,
             )
-        
-        self.token_counter = torch.zeros(batch_size, device=device, dtype=torch.int32)
 
+        self.token_counter = torch.zeros(batch_size, device=device, dtype=torch.int32)
 
     def clear_kv_cache(self) -> None:
         for block in self.transformer.h:
@@ -189,13 +221,21 @@ class Block(nn.Module):
         self.norm_1 = config.norm_class(config.n_embd, eps=config.norm_eps)
         self.attn = CausalSelfAttention(config, block_idx)
         self.post_attention_norm = (
-            config.norm_class(config.n_embd, eps=config.norm_eps) if config.post_attention_norm else nn.Identity()
+            config.norm_class(config.n_embd, eps=config.norm_eps)
+            if config.post_attention_norm
+            else nn.Identity()
         )
-        self.norm_2 = None if config.shared_attention_norm else config.norm_class(config.n_embd, eps=config.norm_eps)
+        self.norm_2 = (
+            None
+            if config.shared_attention_norm
+            else config.norm_class(config.n_embd, eps=config.norm_eps)
+        )
         mlp_class = getattr(sys.modules[__name__], config.mlp_class_name)
         self.mlp = mlp_class(config)
         self.post_mlp_norm = (
-            config.norm_class(config.n_embd, eps=config.norm_eps) if config.post_mlp_norm else nn.Identity()
+            config.norm_class(config.n_embd, eps=config.norm_eps)
+            if config.post_mlp_norm
+            else nn.Identity()
         )
 
         self.config = config
@@ -254,17 +294,26 @@ class CausalSelfAttention(nn.Module):
         # output projection
         # if `head_size` is explicitly specified in the config, `n_emd` might not be equal to `head_size * n_head`
         if not config.tensor_parallel:
-            self.proj = nn.Linear(config.head_size * config.n_head, config.n_embd, bias=config.bias)
+            self.proj = nn.Linear(
+                config.head_size * config.n_head, config.n_embd, bias=config.bias
+            )
         else:
-            self.proj = TPLinear(config.head_size * config.n_head, config.n_embd, bias=config.bias, transpose=True)
+            self.proj = TPLinear(
+                config.head_size * config.n_head,
+                config.n_embd,
+                bias=config.bias,
+                transpose=True,
+            )
         # disabled by default
         self.kv_cache: Optional[KVCache] = None
         self.apply_sliding_window_attention = (
-            config.sliding_window_size is not None and
-            block_idx % config.sliding_window_layer_placing == 0
+            config.sliding_window_size is not None
+            and block_idx % config.sliding_window_layer_placing == 0
         )
-        
-        assert not self.apply_sliding_window_attention, "Sliding window attention is not implemented yet"
+
+        assert (
+            not self.apply_sliding_window_attention
+        ), "Sliding window attention is not implemented yet"
 
         self.config = config
         if config.tensor_parallel:
@@ -274,75 +323,105 @@ class CausalSelfAttention(nn.Module):
             self.config.n_head //= attention_world_size
             assert self.config.n_query_groups % attention_world_size == 0
             self.config.n_query_groups //= attention_world_size
-            
 
     def forward(
         self,
         x: torch.Tensor,
         cos: torch.Tensor,
         sin: torch.Tensor,
-        token_counter: torch.Tensor
+        token_counter: torch.Tensor,
     ) -> torch.Tensor:
-        B, T, C = x.size()  # batch size, sequence length, embedding dimensionality (n_embd)
+        B, T, C = (
+            x.size()
+        )  # batch size, sequence length, embedding dimensionality (n_embd)
 
         qkv = self.attn(x)
 
         # assemble into a number of query groups to support MHA, MQA and GQA together (see `config.n_query_groups`)
         q_per_kv = self.config.n_head // self.config.n_query_groups
         total_qkv = q_per_kv + 2  # each group has 1+ queries, 1 key, and 1 value
-        qkv = qkv.view(B, T, self.config.n_query_groups, total_qkv, self.config.head_size)
+        qkv = qkv.view(
+            B, T, self.config.n_query_groups, total_qkv, self.config.head_size
+        )
 
         # split batched computation into three
         q, k, v = qkv.split((q_per_kv, 1, 1), dim=3)
 
-
         q = q.reshape(B, T, -1, self.config.head_size).contiguous()  # (B, T, nh_q, hs)
         k = k.reshape(B, T, -1, self.config.head_size).contiguous()  # (B, T, nh_k, hs)
         v = v.reshape(B, T, -1, self.config.head_size).contiguous()  # (B, T, nh_v, hs)
-        
-        assert self.config.rope_n_elem == self.config.head_size, "partial rope is not supported yet"
+
+        assert (
+            self.config.rope_n_elem == self.config.head_size
+        ), "partial rope is not supported yet"
 
         k_cache, v_cache = self.kv_cache.k, self.kv_cache.v
 
         if self.apply_sliding_window_attention:
             raise NotImplementedError
-        
-        #y = self.scaled_dot_product_attention(q, k, v, mask)
 
-        y = flash_attn_with_kvcache(q=q, 
-                                    k_cache=k_cache, v_cache=v_cache, 
-                                    k=k, v=v, causal=(T > 1), 
-                                    cache_seqlens=token_counter, 
-                                    rotary_cos=cos, 
-                                    rotary_sin=sin,
-                                    rotary_interleaved=False)
+        # y = self.scaled_dot_product_attention(q, k, v, mask)
 
-        y = y.reshape(B, T, self.config.head_size * self.config.n_head)  # re-assemble all head outputs side by side
+        y = flash_attn_with_kvcache(
+            q=q,
+            k_cache=k_cache,
+            v_cache=v_cache,
+            k=k,
+            v=v,
+            causal=(T > 1),
+            cache_seqlens=token_counter,
+            rotary_cos=cos,
+            rotary_sin=sin,
+            rotary_interleaved=False,
+        )
+
+        y = y.reshape(
+            B, T, self.config.head_size * self.config.n_head
+        )  # re-assemble all head outputs side by side
 
         # output projection
         return self.proj(y)
 
     def scaled_dot_product_attention(
-        self, q: torch.Tensor, k: torch.Tensor, v: torch.Tensor, mask: Optional[torch.Tensor] = None
+        self,
+        q: torch.Tensor,
+        k: torch.Tensor,
+        v: torch.Tensor,
+        mask: Optional[torch.Tensor] = None,
     ) -> torch.Tensor:
-        scale = 1.0 / math.sqrt(self.config.attention_scores_scalar or self.config.head_size)
+        scale = 1.0 / math.sqrt(
+            self.config.attention_scores_scalar or self.config.head_size
+        )
 
         # with softcapping we cannot use SDPA
         if self.config.attention_logit_softcapping is not None:
-            scale = 1.0 / math.sqrt(self.config.attention_scores_scalar or self.config.head_size)
+            scale = 1.0 / math.sqrt(
+                self.config.attention_scores_scalar or self.config.head_size
+            )
             scores = q @ k.mT * scale
             scores = (
-                torch.tanh(scores / self.config.attention_logit_softcapping) * self.config.attention_logit_softcapping
+                torch.tanh(scores / self.config.attention_logit_softcapping)
+                * self.config.attention_logit_softcapping
             )
             if mask is None:
-                mask = torch.ones(q.size(2), q.size(2), dtype=q.dtype, device=q.device).triu(diagonal=1)
+                mask = torch.ones(
+                    q.size(2), q.size(2), dtype=q.dtype, device=q.device
+                ).triu(diagonal=1)
                 mask.masked_fill_(mask.bool(), torch.finfo(q.dtype).min)
             scores = scores + mask
-            scores = torch.nn.functional.softmax(scores, dim=-1, dtype=torch.float).to(dtype=q.dtype)
+            scores = torch.nn.functional.softmax(scores, dim=-1, dtype=torch.float).to(
+                dtype=q.dtype
+            )
             y = scores @ v
         else:
             y = torch.nn.functional.scaled_dot_product_attention(
-                q, k, v, attn_mask=mask, dropout_p=0.0, scale=scale, is_causal=mask is None
+                q,
+                k,
+                v,
+                attn_mask=mask,
+                dropout_p=0.0,
+                scale=scale,
+                is_causal=mask is None,
             )
         return y.transpose(1, 2)
 
@@ -354,12 +433,14 @@ class CausalSelfAttention(nn.Module):
         device: Optional[torch.device] = None,
         dtype: Optional[torch.dtype] = None,
     ) -> "KVCache":
-        
+
         heads = self.config.n_query_groups
         v_shape = (batch_size, max_seq_length, heads, self.config.head_size)
         if rope_cache_length is None:
             if self.config.rotary_percentage != 1.0:
-                raise TypeError("Please pass the `rope_cache_length=gpt.cos.size(-1)` value")
+                raise TypeError(
+                    "Please pass the `rope_cache_length=gpt.cos.size(-1)` value"
+                )
             k_shape = v_shape
         else:
             k_shape = (
@@ -390,11 +471,22 @@ class LLaMAMLP(nn.Module):
     def __init__(self, config: Config) -> None:
         super().__init__()
         if not config.tensor_parallel:
-            self.gate_up_proj = nn.Linear(config.n_embd, 2*config.intermediate_size, bias=config.bias)
-            self.proj = nn.Linear(config.intermediate_size, config.n_embd, bias=config.bias)
+            self.gate_up_proj = nn.Linear(
+                config.n_embd, 2 * config.intermediate_size, bias=config.bias
+            )
+            self.proj = nn.Linear(
+                config.intermediate_size, config.n_embd, bias=config.bias
+            )
         else:
-            self.gate_up_proj = TPLinear(config.n_embd, 2*config.intermediate_size, bias=config.bias)
-            self.proj = TPLinear(config.intermediate_size, config.n_embd, bias=config.bias, transpose=True)
+            self.gate_up_proj = TPLinear(
+                config.n_embd, 2 * config.intermediate_size, bias=config.bias
+            )
+            self.proj = TPLinear(
+                config.intermediate_size,
+                config.n_embd,
+                bias=config.bias,
+                transpose=True,
+            )
 
         self.config = config
 
@@ -409,7 +501,10 @@ class GemmaMLP(LLaMAMLP):
     def forward(self, x: torch.Tensor) -> torch.Tensor:
         x_fc_1 = self.fc_1(x)
         x_fc_2 = self.fc_2(x)
-        x = torch.nn.functional.gelu(x_fc_1, approximate=self.config.gelu_approximate) * x_fc_2
+        x = (
+            torch.nn.functional.gelu(x_fc_1, approximate=self.config.gelu_approximate)
+            * x_fc_2
+        )
         return self.proj(x)
 
 
@@ -427,12 +522,18 @@ class LLaMAMoE(nn.Module):
         Derived from: https://github.com/mistralai/mistral-src/blob/b46d6/moe_one_file_ref.py#L203-L219
         See also figure 1 in https://arxiv.org/abs/2211.15841
         """
-        B, T, C = x.size()  # batch size, sequence length, embedding dimensionality (n_embd)
+        B, T, C = (
+            x.size()
+        )  # batch size, sequence length, embedding dimensionality (n_embd)
         x = x.view(-1, C)  # (B*T, C)
         router = self.gate(x)  # (B*T, n_expert)
-        probs, indices = torch.topk(router, self.config.n_expert_per_token)  # (B*T, n_expert_per_token)
+        probs, indices = torch.topk(
+            router, self.config.n_expert_per_token
+        )  # (B*T, n_expert_per_token)
         probs = probs.softmax(dim=1, dtype=torch.float).to(dtype=x.dtype)
-        masks = indices.unsqueeze(-1) == torch.arange(self.config.n_expert, device=x.device)
+        masks = indices.unsqueeze(-1) == torch.arange(
+            self.config.n_expert, device=x.device
+        )
         masks = masks.permute(2, 0, 1)  # (n_expert, B*T, n_expert_per_token)
         y = torch.zeros_like(x)  # (B*T, C)
         for mask, expert in zip(masks, self.experts):
@@ -486,15 +587,17 @@ def build_rope_cache(
     seq_idx = torch.arange(seq_len, device=device) / condense_ratio
 
     # Calculate the product of position index and $\theta_i$
-    idx_theta = torch.outer(seq_idx, theta) #.repeat(1, 2) repeat is not needed for flash attention
+    idx_theta = torch.outer(
+        seq_idx, theta
+    )  # .repeat(1, 2) repeat is not needed for flash attention
 
     return torch.cos(idx_theta), torch.sin(idx_theta)
+
 
 def batched_index_select(t, dim, idx):
     """index_select for batched index and unbatched t"""
     if idx.dim() == 1:
         return torch.index_select(t, dim, idx)
-
 
     *batch_shape, idx_size = idx.shape
     res = torch.index_select(t, dim, idx.reshape(-1))  # flat index
@@ -502,12 +605,13 @@ def batched_index_select(t, dim, idx):
     res = res.view(*t.shape[:dim], -1, idx_size, *t.shape[dim + 1 :])
     # move batch dim to front, this is np.rollaxis(res, dim, 0) for tensors
     dims = [dim] + list(range(res.dim()))
-    #del dims[dim + 1]
-    dims = dims[:dim + 1] + dims[dim + 2:]
+    # del dims[dim + 1]
+    dims = dims[: dim + 1] + dims[dim + 2 :]
     res = res.permute(dims)
     # unflatten batch dims
     res = res.view(*batch_shape, *res.shape[1:])
     return res
+
 
 def batched_index_copy_(t, dim, idx, val):
     """Index copy for batched t, idx, val"""
@@ -555,9 +659,7 @@ def batched_index_copy_(t, dim, idx, val):
         # fall back to for loop
         for i in range(batch_size):
             unbatched_dim = dim if dim < 0 else dim - 1
-            t[i].index_copy_(unbatched_dim, 
-                            idx[i], 
-                            val[i])
+            t[i].index_copy_(unbatched_dim, idx[i], val[i])
         return t
 
 
@@ -586,17 +688,23 @@ class KVCache(nn.Module):
         dtype: Optional[torch.dtype] = None,
     ) -> None:
         super().__init__()
-        self.register_buffer("k", torch.zeros(k_shape, device=device, dtype=dtype), persistent=False)
-        self.register_buffer("v", torch.zeros(v_shape, device=device, dtype=dtype), persistent=False)
+        self.register_buffer(
+            "k", torch.zeros(k_shape, device=device, dtype=dtype), persistent=False
+        )
+        self.register_buffer(
+            "v", torch.zeros(v_shape, device=device, dtype=dtype), persistent=False
+        )
 
-    def forward(self, input_pos: torch.Tensor, k: torch.Tensor, v: torch.Tensor) -> Tuple[torch.Tensor, torch.Tensor]:
+    def forward(
+        self, input_pos: torch.Tensor, k: torch.Tensor, v: torch.Tensor
+    ) -> Tuple[torch.Tensor, torch.Tensor]:
         # move the buffer to the activation dtype for when AMP is used
         self.k = self.k.to(k.dtype)
         self.v = self.v.to(v.dtype)
         # update the cache
         n = k.size(0)
-        #k = batched_index_copy_(self.k[:n, ...], -2, input_pos, k)
-        #v = batched_index_copy_(self.v[:n, ...], -2, input_pos, v)
+        # k = batched_index_copy_(self.k[:n, ...], -2, input_pos, k)
+        # v = batched_index_copy_(self.v[:n, ...], -2, input_pos, v)
         if input_pos.size(1) > 1:
             # prefill phase
             sequence_length = k.shape[2]
@@ -612,7 +720,6 @@ class KVCache(nn.Module):
         torch.nn.init.zeros_(self.v)
 
 
-
 class RMSNorm(torch.nn.Module):
     """Root Mean Square Layer Normalization.
 
@@ -620,7 +727,9 @@ class RMSNorm(torch.nn.Module):
     https://github.com/bzhangGo/rmsnorm/blob/master/LICENSE.
     """
 
-    def __init__(self, size: int, dim: int = -1, eps: float = 1e-6, add_unit_offset: bool = False) -> None:
+    def __init__(
+        self, size: int, dim: int = -1, eps: float = 1e-6, add_unit_offset: bool = False
+    ) -> None:
         super().__init__()
         self.weight = torch.nn.Parameter(torch.ones(size))
         self.eps = eps

--- a/yalis/external/model.py
+++ b/yalis/external/model.py
@@ -291,31 +291,16 @@ class CausalSelfAttention(nn.Module):
         q_per_kv = self.config.n_head // self.config.n_query_groups
         total_qkv = q_per_kv + 2  # each group has 1+ queries, 1 key, and 1 value
         qkv = qkv.view(B, T, self.config.n_query_groups, total_qkv, self.config.head_size)
-        #qkv = qkv.permute(0, 2, 3, 1, 4)  # (B, n_query_groups, total_qkv, T, hs)
 
         # split batched computation into three
         q, k, v = qkv.split((q_per_kv, 1, 1), dim=3)
 
-        # maybe repeat k and v if for the non multi-head attention cases
-        # training: flash attention requires it
-        # inference: multi-query would require a full kv cache so avoid it to limit its memory usage
-       
-        #print(q_per_kv, self.config.n_head, self.config.n_query_groups) 
-        #assert self.config.n_query_groups == self.config.n_head, "GQA not tested yet"
-        #if self.config.n_query_groups != self.config.n_head:
-        #    k = k.expand(B, self.config.n_query_groups, q_per_kv, T, self.config.head_size)
-        #    v = v.expand(B, self.config.n_query_groups, q_per_kv, T, self.config.head_size)
 
         q = q.reshape(B, T, -1, self.config.head_size).contiguous()  # (B, T, nh_q, hs)
         k = k.reshape(B, T, -1, self.config.head_size).contiguous()  # (B, T, nh_k, hs)
         v = v.reshape(B, T, -1, self.config.head_size).contiguous()  # (B, T, nh_v, hs)
         
         assert self.config.rope_n_elem == self.config.head_size, "partial rope is not supported yet"
-
-        #q_roped = apply_rope(q[..., : self.config.rope_n_elem], cos, sin)
-        #k_roped = apply_rope(k[..., : self.config.rope_n_elem], cos, sin)
-        #q = torch.cat((q_roped, q[..., self.config.rope_n_elem :]), dim=-1)
-        #k = torch.cat((k_roped, k[..., self.config.rope_n_elem :]), dim=-1)
 
         k_cache, v_cache = self.kv_cache.k, self.kv_cache.v
 

--- a/yalis/external/rejection_sampler.py
+++ b/yalis/external/rejection_sampler.py
@@ -11,6 +11,7 @@ import torch
 import torch.jit
 import torch.nn as nn
 
+
 class RejectionSampler(nn.Module):
 
     def __init__(self):
@@ -39,14 +40,14 @@ class RejectionSampler(nn.Module):
         return torch.finfo(self.probs_dtype).tiny
 
     def _create_output(
-            self,
-            accepted: torch.Tensor,  # [batch_size, k]
-            substitute_token_ids: torch.Tensor,  # [batch_size, k]
-            draft_token_ids: torch.Tensor,  # [batch_size, k]
-            bonus_token_ids: torch.Tensor,  # [batch_size]
+        self,
+        accepted: torch.Tensor,  # [batch_size, k]
+        substitute_token_ids: torch.Tensor,  # [batch_size, k]
+        draft_token_ids: torch.Tensor,  # [batch_size, k]
+        bonus_token_ids: torch.Tensor,  # [batch_size]
     ) -> torch.Tensor:
         """Format output. Returns a matrix of token ids. When
-        a token is rejected via sampling, all subsequent token ids are 
+        a token is rejected via sampling, all subsequent token ids are
         set to -1 for the sequence.
 
         Args:
@@ -55,12 +56,12 @@ class RejectionSampler(nn.Module):
             substitute_token_ids: A tensor of token_ids that can be used
             as substitutes for the draft token ids if the proposed token
             is rejected.
-            draft_token_ids: A tensor of token ids speculated by the 
+            draft_token_ids: A tensor of token ids speculated by the
             draft model.
             bonus_token_ids: Token ids to use as the bonus token if
             all the draft tokens are accepted.
         Returns:
-            A tensor containing the accepted token ids. The shape of the 
+            A tensor containing the accepted token ids. The shape of the
             tensor is [batch_size, k + num_bonus_tokens]
         """
         batch_size, k = substitute_token_ids.shape
@@ -77,35 +78,36 @@ class RejectionSampler(nn.Module):
         # Create an extended output tensor
         output_with_bonus_tokens = -torch.ones(
             (batch_size, k + 1),
-            #self._num_bonus_tokens),
+            # self._num_bonus_tokens),
             dtype=self.token_id_dtype,
-            device=accepted.device)
+            device=accepted.device,
+        )
         output = output_with_bonus_tokens[:, :k]
 
         # Fill in the first k columns of the output tensor using masks and data
         # tensors.
-        output[:, :k] = torch.where(accepted_mask, draft_token_ids,
-                                    -torch.ones_like(draft_token_ids))
+        output[:, :k] = torch.where(
+            accepted_mask, draft_token_ids, -torch.ones_like(draft_token_ids)
+        )
 
         # Fill the last column.
         # We check output directly as accepted may have True values inconsistent
         # with causal acceptance.
-        output_with_bonus_tokens[:, -1] = torch.where(output[:, -1] != -1,
-                                                      bonus_token_ids, -1)
+        output_with_bonus_tokens[:, -1] = torch.where(
+            output[:, -1] != -1, bonus_token_ids, -1
+        )
 
         # Fill the recovered token ids.
-        output.mul_(~after_false_mask).add_(
-            substitute_token_ids.mul(after_false_mask))
+        output.mul_(~after_false_mask).add_(substitute_token_ids.mul(after_false_mask))
 
         return output_with_bonus_tokens
 
-
     def forward(
-      self,
-      draft_probs: torch.Tensor,
-      target_probs: torch.Tensor,
-      draft_tokens: torch.Tensor,
-      bonus_tokens: torch.Tensor,
+        self,
+        draft_probs: torch.Tensor,
+        target_probs: torch.Tensor,
+        draft_tokens: torch.Tensor,
+        bonus_tokens: torch.Tensor,
     ):
         batch_size, k, _ = draft_probs.shape
 
@@ -114,12 +116,11 @@ class RejectionSampler(nn.Module):
         # Assuming only one bonus token per batch
         bonus_tokens = bonus_tokens.view(batch_size, 1)
 
-        accepted, recovered_token_ids = (
-            self._batch_modified_rejection_sampling(
+        accepted, recovered_token_ids = self._batch_modified_rejection_sampling(
             target_probs[:, :-1],
             draft_probs,
             draft_tokens,
-        ))
+        )
 
         output_token_ids = self._create_output(
             accepted,
@@ -129,7 +130,6 @@ class RejectionSampler(nn.Module):
         )
 
         return output_token_ids
-
 
     def _batch_modified_rejection_sampling(
         self,
@@ -153,8 +153,9 @@ class RejectionSampler(nn.Module):
         # shape [batch_size, k]
         accepted = self._get_accepted(target_probs, draft_probs, draft_token_ids)
 
-        recovered_probs = self._get_recovered_probs(
-            target_probs, draft_probs).reshape(batch_size * k, vocab_size)
+        recovered_probs = self._get_recovered_probs(target_probs, draft_probs).reshape(
+            batch_size * k, vocab_size
+        )
 
         # NOTE: the recovered_probs are overwritten by this method.
         recovered_token_ids = _multinomial(
@@ -165,12 +166,10 @@ class RejectionSampler(nn.Module):
 
         return accepted, recovered_token_ids
 
-
-    def _create_uniform_samples(self,
-                                batch_size: int, k: int,
-                                device: torch.device) -> torch.Tensor:
+    def _create_uniform_samples(
+        self, batch_size: int, k: int, device: torch.device
+    ) -> torch.Tensor:
         return torch.rand(batch_size, k + 1, device=device)
-
 
     def _get_accepted(
         self,
@@ -199,32 +198,35 @@ class RejectionSampler(nn.Module):
         are accepted.
         """
         batch_size, k, _ = draft_probs.shape
-        batch_indices = torch.arange(batch_size,
-                                     device=target_probs.device)[:, None]
+        batch_indices = torch.arange(batch_size, device=target_probs.device)[:, None]
         probs_indicies = torch.arange(k, device=target_probs.device)
 
         # shape [batch_size, k]
-        selected_draft_probs = draft_probs[batch_indices, probs_indicies,
-                                           draft_token_ids]
+        selected_draft_probs = draft_probs[
+            batch_indices, probs_indicies, draft_token_ids
+        ]
 
         # shape [batch_size, k]
-        selected_target_probs = target_probs[batch_indices, probs_indicies,
-                                             draft_token_ids]
+        selected_target_probs = target_probs[
+            batch_indices, probs_indicies, draft_token_ids
+        ]
 
-        uniform_rand = self._create_uniform_samples(batch_size,
-                                                    k - 1, target_probs.device)
+        uniform_rand = self._create_uniform_samples(
+            batch_size, k - 1, target_probs.device
+        )
 
         capped_ratio = torch.minimum(
             selected_target_probs / selected_draft_probs,
-            torch.full((1, ), 1, device=target_probs.device))
+            torch.full((1,), 1, device=target_probs.device),
+        )
         accepted = uniform_rand < capped_ratio
 
         return accepted
 
     def _get_recovered_probs(
-            self,
-            target_probs: torch.Tensor,  # [k, vocab_size]
-            draft_probs: torch.Tensor,  # [k, vocab_size]
+        self,
+        target_probs: torch.Tensor,  # [k, vocab_size]
+        draft_probs: torch.Tensor,  # [k, vocab_size]
     ) -> torch.Tensor:
         r"""Create a probability distribution for each proposed token which can
         be sampled if the proposed token is rejected.
@@ -288,14 +290,13 @@ def _multinomial(
     if num_samples > 1:
         # This is equivalent to torch.repeat_interleaved (which also
         # forces a GPU<->CPU sync).
-        probs = probs[:, None, :].expand(probs.shape[0], num_samples,
-                                         probs.shape[1]).contiguous().view(
-                                             -1, probs.shape[1])
+        probs = (
+            probs[:, None, :]
+            .expand(probs.shape[0], num_samples, probs.shape[1])
+            .contiguous()
+            .view(-1, probs.shape[1])
+        )
     q = torch.empty_like(probs)
     q.exponential_(1.0)
 
     return probs.div_(q).argmax(dim=1).view(-1, num_samples)
-
-
-
-

--- a/yalis/external/tensor_parallel.py
+++ b/yalis/external/tensor_parallel.py
@@ -83,7 +83,6 @@ def default_init_method(weight):
     return torch.nn.init.kaiming_uniform_(weight, a=math.sqrt(5))
 
 
-
 class TPLinear(torch.nn.Module):
     def __init__(
         self,
@@ -202,9 +201,9 @@ class TPLinear(torch.nn.Module):
         self.state_dict = self._modified_state_dict
 
     def all_reduce(self, x):
-        dist.all_reduce(x, group=self.inner_group)    
+        dist.all_reduce(x, group=self.inner_group)
         return x
-    
+
     def matmul(self, w, x):
         return F.linear(x, w)
 
@@ -234,7 +233,11 @@ class TPLinear(torch.nn.Module):
         )
 
     def _is_sharded_weight_matrix(self, weight):
-        return weight.ndim == 2 and weight.size(0) == self.local_out_features and weight.size(1) == self.local_in_features
+        return (
+            weight.ndim == 2
+            and weight.size(0) == self.local_out_features
+            and weight.size(1) == self.local_in_features
+        )
 
     @torch.no_grad()
     def _modified_load_from_state_dict(self, state_dict, prefix, *args, **kwargs):
@@ -279,7 +282,7 @@ class TPLinear(torch.nn.Module):
     @torch.no_grad()
     def _modified_state_dict(self, *args, **kwargs):
         local_state_dict = self._old_state_dict(*args, **kwargs)
-        weight_key, bias_key = None, None    
+        weight_key, bias_key = None, None
         for key in local_state_dict:
             if "weight" in key:
                 weight_key = key
@@ -287,15 +290,19 @@ class TPLinear(torch.nn.Module):
                 bias_key = key
         local_weight = local_state_dict[weight_key]
         global_weight = gather_full_params_from_local_params(
-            local_weight, self.outer_group, self.inner_group, self.depth_group, (self.local_out_features, self.local_in_features)
+            local_weight,
+            self.outer_group,
+            self.inner_group,
+            self.depth_group,
+            (self.local_out_features, self.local_in_features),
         )
         if bias_key is not None:
             local_bias = local_state_dict[bias_key]
-            global_bias = Gather.apply(local_bias, self.outer_group) 
+            global_bias = Gather.apply(local_bias, self.outer_group)
 
         if torch.distributed.get_rank() == 0:
             local_state_dict[weight_key] = global_weight.cpu()
             if bias_key is not None:
                 local_state_dict[bias_key] = global_bias
-        
+
         return local_state_dict

--- a/yalis/external/test_loading_checkpoint.py
+++ b/yalis/external/test_loading_checkpoint.py
@@ -6,7 +6,9 @@ import torch
 from model import GPT
 
 if __name__ == "__main__":
-    checkpoint_dir = Path("./checkpoints/TinyLlama/TinyLlama-1.1B-intermediate-step-1431k-3T")
+    checkpoint_dir = Path(
+        "./checkpoints/TinyLlama/TinyLlama-1.1B-intermediate-step-1431k-3T"
+    )
     config = Config.from_file(checkpoint_dir / "model_config.yaml")
     model = GPT(config)
 
@@ -15,5 +17,3 @@ if __name__ == "__main__":
     model.load_state_dict(state_dict)
     print("successfully loaded model")
     print(model.state_dict().keys())
-
-

--- a/yalis/initialize.py
+++ b/yalis/initialize.py
@@ -31,7 +31,6 @@ def init_distributed():
             accelerator="gpu",
             devices=1,
             num_nodes=1,
-            precision=dtype,
         )
     fabric.launch()
     # this is very important to ensure that the same token is sampled on each TP rank!

--- a/yalis/initialize.py
+++ b/yalis/initialize.py
@@ -6,6 +6,7 @@ import torch.distributed as dist
 
 yalis_fabric = None
 
+
 def init_distributed():
     global yalis_fabric
     if yalis_fabric is not None:
@@ -14,12 +15,12 @@ def init_distributed():
     world_size = dist.get_world_size()
     if world_size > 1:
         strategy = AxonnStrategy(
-                G_intra_r=world_size,
-                G_intra_c=1,
-                G_intra_d=1,
-                overlap_communication=True,
-                enable_timers=False,
-            )
+            G_intra_r=world_size,
+            G_intra_c=1,
+            G_intra_d=1,
+            overlap_communication=True,
+            enable_timers=False,
+        )
         fabric = Fabric(
             accelerator="gpu",
             devices=torch.cuda.device_count(),
@@ -38,4 +39,3 @@ def init_distributed():
     seed_everything(1234)
     yalis_fabric = fabric
     return fabric
-

--- a/yalis/model.py
+++ b/yalis/model.py
@@ -7,11 +7,9 @@ from yalis.external.model import GPT
 import torch.distributed as dist
 
 
-def get_model(fabric, 
-            litgpt_checkpoint_directory, 
-            model_dtype, 
-            random_init=False,
-            device="cuda"):
+def get_model(
+    fabric, litgpt_checkpoint_directory, model_dtype, random_init=False, device="cuda"
+):
     tensor_parallel = dist.get_world_size() > 1
     if tensor_parallel and dist.get_rank() == 0:
         print(f"Using Tensor parallelism on {dist.get_world_size()} GPUs")

--- a/yalis/pipelines/__init__.py
+++ b/yalis/pipelines/__init__.py
@@ -1,2 +1,4 @@
 from .basic_inference_pipeline import BasicInferencePipeline as BasicInferencePipeline
-from .speculative_pipeline import SpeculativeDecodingPipeline as SpeculativeDecodingPipeline
+from .speculative_pipeline import (
+    SpeculativeDecodingPipeline as SpeculativeDecodingPipeline,
+)

--- a/yalis/pipelines/base_pipeline.py
+++ b/yalis/pipelines/base_pipeline.py
@@ -1,5 +1,6 @@
 import torch
 from yalis import print_rank0
+
 torch._inductor.config.coordinate_descent_tuning = True
 torch._inductor.config.triton.unique_kernel_names = True
 torch._inductor.config.fx_graph_cache = True  # Experimental feature to reduce compilation times, will be on by default in future
@@ -15,18 +16,22 @@ def prefill(model, tokens):
     token_id = torch.argmax(logits[0, -1])
     return token_id
 
-#todo - verify does not work
-#@torch.compile(fullgraph=True)
+
+# todo - verify does not work
+# @torch.compile(fullgraph=True)
 @torch.no_grad()
 def verify(model, tokens, target_pos):
     # Forward pass through the model
     # print (target_pos)
-    input_pos = target_pos + torch.arange(0, tokens.size(0), device="cuda", dtype=torch.int64)
+    input_pos = target_pos + torch.arange(
+        0, tokens.size(0), device="cuda", dtype=torch.int64
+    )
     logits = model(tokens.view(1, -1), input_pos)["logits"]
-    #print (logits.size())
+    # print (logits.size())
     token_id = torch.argmax(logits[0, -1])
     return token_id, logits
-    
+
+
 @torch.no_grad()
 @torch.compile(fullgraph=True, mode="reduce-overhead")
 def generate(model, tokens, input_pos, get_probs=False):
@@ -37,6 +42,7 @@ def generate(model, tokens, input_pos, get_probs=False):
         return token_id, logits
     else:
         return token_id
+
 
 # This is the base class defining the interface of all pipelines
 class BasePipeline:

--- a/yalis/pipelines/basic_inference_pipeline.py
+++ b/yalis/pipelines/basic_inference_pipeline.py
@@ -4,31 +4,33 @@ from yalis import print_rank0
 from typing import Optional
 import time
 
+
 class BasicInferencePipeline(BasePipeline):
-    def __init__(self, 
-                 model, 
-                 tokenizer,
-                 dtype,
-                 device,):
+    def __init__(
+        self,
+        model,
+        tokenizer,
+        dtype,
+        device,
+    ):
         super().__init__(device)
         self.model = model
         self.dtype = dtype
         self.tokenizer = tokenizer
 
+    def setup(self, batch_size: Optional[int] = 1):
+        self.model.set_kv_cache(
+            batch_size=batch_size, device=self.device, dtype=self.dtype
+        )
 
-    def setup(self, 
-              batch_size: Optional[int] = 1):
-        self.model.set_kv_cache(batch_size=batch_size, device=self.device, dtype=self.dtype)
+    def run(self, prompt, tokens_to_gen, profile: Optional[bool] = True):
 
-
-
-    def run(self, 
-            prompt, 
-            tokens_to_gen,
-            profile: Optional[bool] = True):
-        
         # Caching the attributes to local variables improves performance
-        prompt_tokens = self.tokenizer(prompt, return_tensors="pt")["input_ids"].squeeze().to(self.device)
+        prompt_tokens = (
+            self.tokenizer(prompt, return_tensors="pt")["input_ids"]
+            .squeeze()
+            .to(self.device)
+        )
 
         if profile:
             num_trials = 10
@@ -38,21 +40,28 @@ class BasicInferencePipeline(BasePipeline):
 
         # Generation loop
         # Using Cuda events instead of time.time(). Synchronizing was important as adding that gave a slighlty lower performance
-        #print("\nStarting token generation:")
+        # print("\nStarting token generation:")
         for TRIAL in range(10):
             start = torch.cuda.Event(enable_timing=True)
             end = torch.cuda.Event(enable_timing=True)
             start.record()
             output_tokens = []
-            with torch.no_grad(), torch.autocast(self.device, dtype=self.dtype, cache_enabled=False):
+            with torch.no_grad(), torch.autocast(
+                self.device, dtype=self.dtype, cache_enabled=False
+            ):
                 for step in range(tokens_to_gen):
-                    if step == 0: # prefill
+                    if step == 0:  # prefill
                         next_token = prefill(self.model, prompt_tokens)
-                        input_pos = torch.tensor([prompt_tokens.size(0)], device=self.device, dtype=torch.int64)
+                        input_pos = torch.tensor(
+                            [prompt_tokens.size(0)],
+                            device=self.device,
+                            dtype=torch.int64,
+                        )
                         tokens = next_token.clone()
                     else:
                         with torch.nn.attention.sdpa_kernel(
-                                    torch.nn.attention.SDPBackend.MATH):
+                            torch.nn.attention.SDPBackend.MATH
+                        ):
                             next_token = generate(self.model, tokens, input_pos)
                             input_pos.add_(1)
                             tokens.copy_(next_token)
@@ -64,7 +73,7 @@ class BasicInferencePipeline(BasePipeline):
 
             if profile and TRIAL >= num_warumups:
                 tokens_per_second = len(output_tokens) / time_taken
-                print_rank0(f"[Iter:{TRIAL}]Output {tokens_per_second} tok/s") 
+                print_rank0(f"[Iter:{TRIAL}]Output {tokens_per_second} tok/s")
 
         generated_text = self.tokenizer.decode([x.item() for x in output_tokens])
         print_rank0("-" * 40)

--- a/yalis/pipelines/speculative_pipeline.py
+++ b/yalis/pipelines/speculative_pipeline.py
@@ -5,13 +5,16 @@ from yalis import print_rank0
 from typing import Optional
 import time
 
+
 class SpeculativeDecodingPipeline(BasePipeline):
-    def __init__(self, 
-                 target_model, 
-                 draft_model,
-                 tokenizer,
-                 dtype,
-                 device,):
+    def __init__(
+        self,
+        target_model,
+        draft_model,
+        tokenizer,
+        dtype,
+        device,
+    ):
         pass
         super().__init__(device)
         self.target_model = target_model
@@ -19,22 +22,24 @@ class SpeculativeDecodingPipeline(BasePipeline):
         self.tokenizer = tokenizer
         self.dtype = dtype
         self.sampler = RejectionSampler()
-        #self.sampler = torch.compile(self.sampler, fullgraph=True)
+        # self.sampler = torch.compile(self.sampler, fullgraph=True)
 
+    def setup(self, batch_size: Optional[int] = 1):
+        self.target_model.set_kv_cache(
+            batch_size=batch_size, device=self.device, dtype=self.dtype
+        )
+        self.draft_model.set_kv_cache(
+            batch_size=batch_size, device=self.device, dtype=self.dtype
+        )
 
-    def setup(self, 
-              batch_size: Optional[int] = 1):
-        self.target_model.set_kv_cache(batch_size=batch_size, device=self.device, dtype=self.dtype)
-        self.draft_model.set_kv_cache(batch_size=batch_size, device=self.device, dtype=self.dtype)
+    def run(self, prompt, tokens_to_gen, gamma, profile: Optional[bool] = True):
 
-    def run(self, 
-            prompt, 
-            tokens_to_gen,
-            gamma,
-            profile: Optional[bool] = True):
-        
         # Caching the attributes to local variables improves performance
-        prompt_tokens = self.tokenizer(prompt, return_tensors="pt")["input_ids"].squeeze().to(self.device)
+        prompt_tokens = (
+            self.tokenizer(prompt, return_tensors="pt")["input_ids"]
+            .squeeze()
+            .to(self.device)
+        )
 
         if profile:
             num_trials = 10
@@ -44,27 +49,34 @@ class SpeculativeDecodingPipeline(BasePipeline):
 
         # Generation loop
         # Using Cuda events instead of time.time(). Synchronizing was important as adding that gave a slighlty lower performance
-        #print("\nStarting token generation:")
+        # print("\nStarting token generation:")
         for TRIAL in range(10):
             start = torch.cuda.Event(enable_timing=True)
             end = torch.cuda.Event(enable_timing=True)
             start.record()
             output_tokens = []
-            with torch.no_grad(), torch.autocast(self.device, dtype=self.dtype, cache_enabled=False):
+            with torch.no_grad(), torch.autocast(
+                self.device, dtype=self.dtype, cache_enabled=False
+            ):
                 generated_tokens = 0
                 while generated_tokens < tokens_to_gen:
-                    if generated_tokens == 0: # Prefill
+                    if generated_tokens == 0:  # Prefill
                         # Only the target model is used for prefilling
                         next_token = prefill(self.target_model, prompt_tokens)
-                        target_input_pos = torch.tensor([prompt_tokens.size(0)], device=self.device, dtype=torch.int64)
+                        target_input_pos = torch.tensor(
+                            [prompt_tokens.size(0)],
+                            device=self.device,
+                            dtype=torch.int64,
+                        )
                         tokens = next_token.clone()
                         generated_tokens += 1
                         output_tokens.append(next_token.clone())
 
                         _ = prefill(self.draft_model, prompt_tokens)
-                    else: # Decode
+                    else:  # Decode
                         with torch.nn.attention.sdpa_kernel(
-                                    torch.nn.attention.SDPBackend.MATH):
+                            torch.nn.attention.SDPBackend.MATH
+                        ):
                             # Draft tokens
                             draft_input_pos = target_input_pos.clone()
                             draft_tokens = tokens.clone()
@@ -74,29 +86,49 @@ class SpeculativeDecodingPipeline(BasePipeline):
                             draft_probs = []
                             for draft_step in range(gamma):
                                 # Get next draft token and its probabilities
-                                next_token, probs = generate(self.draft_model, draft_tokens, draft_input_pos, get_probs=True)
+                                next_token, probs = generate(
+                                    self.draft_model,
+                                    draft_tokens,
+                                    draft_input_pos,
+                                    get_probs=True,
+                                )
                                 draft_input_pos.add_(1)
                                 draft_tokens.copy_(next_token)
 
                                 draft_probs.append(probs.clone())
                                 draft_output_tokens.append(next_token.clone())
-                            
+
                             draft_probs = torch.cat(draft_probs, dim=1)
                             draft_output_tokens = torch.stack(draft_output_tokens)
 
                             # Verify the output of the draft model
-                            next_token, target_probs = verify(self.target_model, draft_output_tokens, target_input_pos)
+                            next_token, target_probs = verify(
+                                self.target_model, draft_output_tokens, target_input_pos
+                            )
                             # Rejection Sampling
-                            output_with_bonus_tokens = self.sampler(draft_probs, target_probs, draft_output_tokens[1:], next_token)
-                            assert output_with_bonus_tokens.size(0) == 1 # Only batch size 1 is supported
+                            output_with_bonus_tokens = self.sampler(
+                                draft_probs,
+                                target_probs,
+                                draft_output_tokens[1:],
+                                next_token,
+                            )
+                            assert (
+                                output_with_bonus_tokens.size(0) == 1
+                            )  # Only batch size 1 is supported
 
-                            output_with_bonus_tokens = output_with_bonus_tokens.squeeze()
-                            mask_negative = (output_with_bonus_tokens == -1)
+                            output_with_bonus_tokens = (
+                                output_with_bonus_tokens.squeeze()
+                            )
+                            mask_negative = output_with_bonus_tokens == -1
                             if mask_negative.any():
-                                num_accepted_tokens = mask_negative.nonzero(as_tuple=True)[0][0]
+                                num_accepted_tokens = mask_negative.nonzero(
+                                    as_tuple=True
+                                )[0][0]
                             else:
                                 num_accepted_tokens = output_with_bonus_tokens.size(0)
-                            output_with_bonus_tokens = output_with_bonus_tokens[:num_accepted_tokens]
+                            output_with_bonus_tokens = output_with_bonus_tokens[
+                                :num_accepted_tokens
+                            ]
 
                             accepted_tokens = torch.unbind(output_with_bonus_tokens)
 
@@ -111,7 +143,7 @@ class SpeculativeDecodingPipeline(BasePipeline):
 
             if profile and TRIAL >= num_warumups:
                 tokens_per_second = len(output_tokens) / time_taken
-                print_rank0(f"[Iter:{TRIAL}]Output {tokens_per_second} tok/s") 
+                print_rank0(f"[Iter:{TRIAL}]Output {tokens_per_second} tok/s")
 
         generated_text = self.tokenizer.decode([x.item() for x in output_tokens])
         print_rank0("-" * 40)

--- a/yalis/utils.py
+++ b/yalis/utils.py
@@ -1,7 +1,6 @@
 import torch.distributed as dist
 
+
 def print_rank0(msg):
     if dist.get_rank() == 0:
         print(f"{msg}")
-
-


### PR DESCRIPTION
- switching to the fused flash attention kernel that does kv caching, rope and attention in one go. 
- removing pesky input_pos. Token position counts are maintained by the kv cache.
- for gqa, only cache unique "heads". Earlier we were wasting memory by caching duplicate kvs