### PR TITLE
make model buffers and parameter tensors contiguous

### DIFF
--- a/yalis/engine.py
+++ b/yalis/engine.py
@@ -94,7 +94,35 @@ class LLMEngine:
         self.dtype = precision_to_dtype[self.model_config.precision]
         init_distributed()
         self._initialize_model()
+        self._make_params_contiguous()
         torch.cuda.empty_cache()  # return extra memory to CUDA. Can prevent NCCL init OOMs
+
+    def _make_params_contiguous(self):
+        if not self.model:
+            print_rank0("Model must be initialized before contiguous parameter buffer can be allocated")
+            return
+        
+        total_bytes = 0
+        param_info = []
+        
+        for name, param in self.model.named_parameters():
+            num_bytes = param.numel() * param.element_size()
+            param_info.append({
+                "name": name,
+                "shape": param.shape,
+                "dtype": param.dtype,
+                "num_bytes": num_bytes,
+                "offset": total_bytes,
+                "param": param,
+            })
+            total_bytes += num_bytes
+
+        storage = torch.empty(total_bytes, dtype=torch.uint8, device='cuda')
+
+        for info in param_info:
+            param_view = storage[info["offset"]: info["offset"] + info["num_bytes"]].view(info["dtype"]).reshape(info["shape"])
+            param_view.copy_(info["param"], non_blocking=True)
+            info["param"].data = param_view
 
     def _initialize_model(self):
         """

--- a/yalis/engine.py
+++ b/yalis/engine.py
@@ -94,7 +94,6 @@ class LLMEngine:
         self.dtype = precision_to_dtype[self.model_config.precision]
         init_distributed()
         self._initialize_model()
-        self._make_params_contiguous()
         torch.cuda.empty_cache()  # return extra memory to CUDA. Can prevent NCCL init OOMs
 
     def _make_params_contiguous(self):
@@ -103,7 +102,7 @@ class LLMEngine:
             return
         
         total_bytes = 0
-        param_info = []
+        param_info, buf_info = [], []
         
         for name, param in self.model.named_parameters():
             num_bytes = param.numel() * param.element_size()
@@ -116,13 +115,33 @@ class LLMEngine:
                 "param": param,
             })
             total_bytes += num_bytes
+        
+        for name, buf in self.model.named_buffers():
+            num_bytes = buf.numel() * buf.element_size()
+            buf_info.append({
+                "name": name,
+                "shape": buf.shape,
+                "dtype": buf.dtype,
+                "num_bytes": num_bytes,
+                "offset": total_bytes,
+                "buf": buf,
+            })
+            total_bytes += num_bytes
 
-        storage = torch.empty(total_bytes, dtype=torch.uint8, device='cuda')
+        # make buffer 128-byte aligned
+        total_bytes = total_bytes - (total_bytes % 128) + 128
+
+        gpu_buffer = torch.empty(total_bytes, dtype=torch.uint8, device="cuda")
 
         for info in param_info:
-            param_view = storage[info["offset"]: info["offset"] + info["num_bytes"]].view(info["dtype"]).reshape(info["shape"])
+            param_view = gpu_buffer[info["offset"]: info["offset"] + info["num_bytes"]].view(info["dtype"]).reshape(info["shape"])
             param_view.copy_(info["param"], non_blocking=True)
             info["param"].data = param_view
+
+        for info in buf_info:
+            buf_view = gpu_buffer[info["offset"]: info["offset"] + info["num_bytes"]].view(info["dtype"]).reshape(info["shape"])
+            buf_view.copy_(info["buf"], non_blocking=True)
+            info["buf"].data = buf_view
 
     def _initialize_model(self):
         """
@@ -131,6 +150,7 @@ class LLMEngine:
         print_rank0(f"Initializing model: {self.model_config.model_name}")
         print_rank0(f"Using precision: {self.model_config.precision}")
         self.model = get_model(self.model_config.model_path, self.dtype, max_sequence_length=self.inference_config.max_length)
+        self._make_params_contiguous()
         self.model.set_kv_cache(
             batch_size=self.inference_config.batch_size,
             device=self.device,

--- a/yalis/model.py
+++ b/yalis/model.py
@@ -25,7 +25,7 @@ def get_model(
         ), f"Maximum sequence length for this model is {config.block_size}"
         config.block_size = max_sequence_length
     config.tensor_parallel = tensor_parallel
-    model = GPT(config).to(device).to(model_dtype)
+    model = GPT(config).to(model_dtype)
     if not random_init:
         checkpoint_path = checkpoint_dir / "lit_model.pth"
         load_checkpoint(model, checkpoint_path)


### PR DESCRIPTION
This PR addresses issue #21 by ensuring that all model buffers and parameter tensors within a GPU's global memory are stored contiguously. This helps avoid external fragmentation and may also result in slightly increased throughput because of more cache hits.

Experimentally observed an increase in throughput by ~ 4 tok/s for BS=8 and generation length = 512.
(Left fig is without contiguous tensors and right fig is with contiguous tensors)

<img width="194" alt="image" src="https://github.com/user-attachments/assets/8b5a8d9a-b30a-43f8-bdb4-6ecda77b1f7e" /> --->  <img width="191" alt="image" src="https://github.com/user-attachments/assets/76ee331e-37ac-41cf-a99c-4364c77c35c5" />

