### PR TITLE
move default location for TPLinear modules to CPU

### DIFF
--- a/yalis/external/tensor_parallel.py
+++ b/yalis/external/tensor_parallel.py
@@ -68,7 +68,7 @@ def initialize_params(
     out_features_group,
     in_features_group,
     init_method,
-    init_device="cuda",
+    init_device="cpu",
 ):
     params = torch.empty((out_features, in_features), device=init_device)
     init_method(params)


### PR DESCRIPTION
In PR #23, allocating a buffer in GPU memory and directly moving all model buffers and params from the CPU to this GPU buffer resulted in the max memory being allocated on each GPU to reduce from 12.234801152 GB to 9.082765312 GB. This was using the Llama-3-8B-Instruct model with tensor parallelism across 4 GPUs. However, I found it weird that an 8B model in 16-bit precision which should take up ~16GB of memory in total and thus ~4GB of memory **per GPU** across 4 GPUs using TP is still causing an allocation of ~9GB on each GPU, so I decided to look into it.

Turns out that the default location for initializing params for TPLinear modules was set to CUDA, which is why even after removing the `model.to("cuda")` call in the `get_model` func in #23, the linear params were still being allocated on the GPUs, along with our new GPU-buffer, causing duplicate allocations.

Old (TPLinear modules allocated in GPU memory)
```
AFTER GET_MODEL: 7.860125696 GB <---- this shouldn't be allocating anything on the GPU
AFTER CONTIGUOUS: 9.082765312 GB
AFTER SET KV CACHE: 9.082765312 GB <--- this number is the same as AFTER_CONTIGUOUS since pytorch is just re-using freed memory blocks in the memory pool now, which means we were allocating more than we needed
```

New (TPLinear modules allocated in CPU memory and then moved to GPU buffer)
```
AFTER GET_MODEL: 0.0 GB
AFTER CONTIGUOUS: 5.593104384 GB
AFTER SET KV CACHE: 5.861540352 GB
```

Now, we are correctly allocating ~4GB per GPU across 4 GPUs. This change doesn't really matter since allocating more than we needed before the change would just result in us re-using the duplicate allocation. But this is the correct way of doing it.

Also this change makes throughput go up again! Although it is negligible and also unexplainable