### PR TITLE
[WIP] move flash kernel flag to model config and add flash attn to install script

### DIFF
--- a/examples/infer.py
+++ b/examples/infer.py
@@ -64,7 +64,7 @@ if __name__ == "__main__":
     tokens_to_gen = 512
 
     # configs
-    model_config = ModelConfig(model_name=model_id, precision="bf16")
+    model_config = ModelConfig(model_name=model_id, explicitly_use_flash_kernel=False, precision="bf16")
     inference_config = InferenceConfig(batch_size=len(input_prompts), 
                                        max_length_of_generated_sequences=1024,
                                        top_p=0.80,

--- a/scripts/create_python_env_perlmutter.sh
+++ b/scripts/create_python_env_perlmutter.sh
@@ -45,6 +45,7 @@ pip install litgpt --no-deps
 pip install lightning
 pip install transformers
 pip install datasets
+pip install flash-attn==2.6.3 --no-build-isolation
 
 python -c "import torch; print(torch.__version__)"
 echo -e "${RED}Your Python Environment is ready. To activate it run the following commands in the SAME order:${NC}"

--- a/yalis/config.py
+++ b/yalis/config.py
@@ -11,6 +11,7 @@ class ModelConfig:
         self,
         model_name: str,
         model_path: Optional[str] = None,
+        explicitly_use_flash_kernel: Optional[bool] = False,
         precision: Literal["fp32", "fp16", "bf16"] = "fp16",
     ):
         """
@@ -25,6 +26,7 @@ class ModelConfig:
         # we should par
         self.model_name = model_name
         self.model_path = model_path
+        self.explicitly_use_flash_kernel = explicitly_use_flash_kernel
         self.precision = precision
         self._validate()
         self.model_path = self._resolve_model_path(self.model_path)
@@ -72,6 +74,7 @@ class ModelConfig:
     def __repr__(self):
         return (
             f"ModelConfig(model_name={self.model_name}, model_path={self.model_path}, "
+            f"explicitly_use_flash_kernel={self.explicitly_use_flash_kernel}"
             f"precision={self.precision}"
         )
 

--- a/yalis/engine.py
+++ b/yalis/engine.py
@@ -149,7 +149,12 @@ class LLMEngine:
         """
         print_rank0(f"Initializing model: {self.model_config.model_name}")
         print_rank0(f"Using precision: {self.model_config.precision}")
-        self.model = get_model(self.model_config.model_path, self.dtype, max_sequence_length=self.inference_config.max_length)
+        self.model = get_model(
+            self.model_config.model_path, 
+            self.dtype, 
+            max_sequence_length=self.inference_config.max_length, 
+            explicitly_use_flash_kernel=self.model_config.explicitly_use_flash_kernel,
+        )
         self._make_params_contiguous()
         self.model.set_kv_cache(
             batch_size=self.inference_config.batch_size,

--- a/yalis/external/model.py
+++ b/yalis/external/model.py
@@ -13,13 +13,6 @@ import torch
 import torch.nn as nn
 from typing_extensions import Self
 
-try:
-    from flash_attn import flash_attn_with_kvcache
-    has_flash_attn = True
-except ImportError:
-    flash_attn_with_kvcache = None
-    has_flash_attn = False
-
 from litgpt.config import Config
 import sys
 
@@ -37,8 +30,8 @@ class GPT(nn.Module):
         super().__init__()
         assert config.padded_vocab_size is not None
         self.config = config
-        self.config.explicitly_use_flash_kernel = True
-        self.config.explicitly_use_flash_kernel = self.config.explicitly_use_flash_kernel and has_flash_attn
+        if self.config.explicitly_use_flash_kernel:
+            from flash_attn import flash_attn_with_kvcache
         print_rank0(
             f"Explicit Flash Kernel Usage = {self.config.explicitly_use_flash_kernel}"
         )

--- a/yalis/model.py
+++ b/yalis/model.py
@@ -11,6 +11,7 @@ def get_model(
     litgpt_checkpoint_directory,
     model_dtype,
     max_sequence_length=None,
+    explicitly_use_flash_kernel=False,
     random_init=False,
     device="cuda",
 ):
@@ -25,6 +26,7 @@ def get_model(
         ), f"Maximum sequence length for this model is {config.block_size}"
         config.block_size = max_sequence_length
     config.tensor_parallel = tensor_parallel
+    config.explicitly_use_flash_kernel = explicitly_use_flash_kernel
     model = GPT(config).to(model_dtype)
     if not random_init:
         checkpoint_path = checkpoint_dir / "lit_model.pth"


### PR DESCRIPTION
This PR moves the `model.config.explicitly_use_flash_kernel` variable to the ModelConfig and also includes flash-attn in the install script.