### PR TITLE
[Fix] Model Init Times Reduction using Meta Tensors and Empty Init

### DIFF
--- a/yalis/engine.py
+++ b/yalis/engine.py
@@ -9,7 +9,7 @@ import logging
 import torch.distributed as dist
 from transformers import AutoTokenizer
 from torch.nn.attention import SDPBackend, sdpa_kernel
-
+import time
 
 # These flags are taken from the following URL -
 # https://github.com/pytorch/pytorch/blob/347f96061f1cff603983b9be19ec92b374329a5b/benchmarks/gpt_fast/generate.py#L19
@@ -147,6 +147,7 @@ class LLMEngine:
         """
         Internal method to load and set up the model based on ModelConfig.
         """
+        t0 = time.time()
         print_rank0(f"Initializing model: {self.model_config.model_name}")
         print_rank0(f"Using precision: {self.model_config.precision}")
         self.model = get_model(self.model_config.model_path, self.dtype, max_sequence_length=self.inference_config.max_length)
@@ -163,6 +164,7 @@ class LLMEngine:
             print_rank0(
                 "Pad token not found in the tokenizer. Using eos_token as pad token."
             )
+        print_rank0(f"Initializing Model took {time.time() - t0} seconds")
 
     def generate(
         self,

--- a/yalis/external/litgpt_utils.py
+++ b/yalis/external/litgpt_utils.py
@@ -2,6 +2,40 @@ from litgpt.utils import lazy_load
 import torch.nn as nn
 from pathlib import Path
 
+# From https://lernapparat.de/faster-model-init by Thomas Viehmann
+class _EmptyInit(TorchFunctionMode):
+    """Initialize `nn.Module` with empty tensors, i.e., uninitialized memory.
+
+    Example::
+
+        with _EmptyInit():
+            model = BigModel()
+        model.load_state_dict(torch.load("checkpoint.pt"))
+
+    """
+
+    def __init__(self, enabled: bool = True) -> None:
+        super().__init__()
+        self.enabled = enabled
+
+    @override
+    def __torch_function__(
+        self,
+        func: Callable,
+        types: Sequence,
+        args: Sequence[Any] = (),
+        kwargs: Optional[dict] = None,
+    ) -> Any:
+        kwargs = kwargs or {}
+        if not self.enabled:
+            return func(*args, **kwargs)
+        if getattr(func, "__module__", None) == "torch.nn.init":
+            if "tensor" in kwargs:
+                return kwargs["tensor"]
+            return args[0]
+        return func(*args, **kwargs)
+
+
 def load_checkpoint(model: nn.Module, 
                     checkpoint_path: Path, 
                     strict: bool = True) -> None:

--- a/yalis/external/model.py
+++ b/yalis/external/model.py
@@ -30,6 +30,7 @@ from axonn import axonn as ax
 from axonn.intra_layer.communication import Drop, Gather
 
 from yalis import print_rank0
+import time
 
 
 class GPT(nn.Module):
@@ -310,7 +311,7 @@ class CausalSelfAttention(nn.Module):
         if not config.tensor_parallel:
             self.attn = nn.Linear(config.n_embd, shape, bias=config.bias)
         else:
-            self.attn = TPLinear(config.n_embd, shape, bias=config.bias)
+            self.attn = TPLinear(config.n_embd, shape, bias=config.bias, init_device=config.init_device)
 
         # output projection
         # if `head_size` is explicitly specified in the config, `n_emd` might not be equal to `head_size * n_head`
@@ -324,6 +325,7 @@ class CausalSelfAttention(nn.Module):
                 config.n_embd,
                 bias=config.bias,
                 transpose=True,
+                init_device=config.init_device
             )
         # disabled by default
         self.kv_cache: Optional[KVCache] = None
@@ -641,13 +643,14 @@ class LLaMAMLP(nn.Module):
             )
         else:
             self.gate_up_proj = TPLinear(
-                config.n_embd, 2 * config.intermediate_size, bias=config.bias
+                config.n_embd, 2 * config.intermediate_size, bias=config.bias, init_device=config.init_device
             )
             self.proj = TPLinear(
                 config.intermediate_size,
                 config.n_embd,
                 bias=config.bias,
                 transpose=True,
+                init_device=config.init_device,
             )
 
         self.config = config

--- a/yalis/external/tensor_parallel.py
+++ b/yalis/external/tensor_parallel.py
@@ -95,11 +95,16 @@ class TPLinear(torch.nn.Module):
         init_method=None,
         expert_mode=True,
         tensor_parallel_dims: Optional[Sequence[int]] = None,
+        init_device="meta",
         **kwargs,
     ):
         super(TPLinear, self).__init__()
         assert expert_mode, "Only expert mode allowed in inference"
 
+        self.init_device = init_device
+        #TODO: Change this to a soft assert and show a warning instead
+        assert init_device == "meta", "Parameter initialization allowed only on meta device"
+    
         # weights are shaped [out_features, in_features]
         # in_features are distributed across self.inner_group (X tensor parallel group)
         # out_features are distributed across self.inner_group (Y tensor parallel group)
@@ -156,6 +161,7 @@ class TPLinear(torch.nn.Module):
             self.outer_group,
             self.inner_group,
             init_method,
+            init_device=self.init_device
         )
         # register the weight matrix as a trainable parameter.
         self.weight = torch.nn.Parameter(initial_params, requires_grad=True)
@@ -175,6 +181,7 @@ class TPLinear(torch.nn.Module):
             self.bias = torch.nn.Parameter(
                 torch.zeros(
                     self.local_out_features,
+                    device=self.init_device
                 )
             )
             setattr(self.bias, "is_tensor_parallel", True)
@@ -241,6 +248,11 @@ class TPLinear(torch.nn.Module):
 
     @torch.no_grad()
     def _modified_load_from_state_dict(self, state_dict, prefix, *args, **kwargs):
+        # If the parameters were initialized on meta-device, we need to materialize them here
+        if self.init_device == "meta":
+            self.to_empty(device="cpu")
+            self.init_device = "cpu"
+
         weight = (
             state_dict[prefix + "weight"] if prefix + "weight" in state_dict else None
         )

--- a/yalis/model.py
+++ b/yalis/model.py
@@ -2,10 +2,9 @@ import torch
 from litgpt.model import Config
 from pathlib import Path
 import sys
-from yalis.external.litgpt_utils import load_checkpoint
+from yalis.external.litgpt_utils import load_checkpoint, _EmptyInit
 from yalis.external.model import GPT
 import torch.distributed as dist
-from lightning.fabric.utilities.init import _EmptyInit
 import time
 
 

--- a/yalis/model.py
+++ b/yalis/model.py
@@ -5,6 +5,8 @@ import sys
 from yalis.external.litgpt_utils import load_checkpoint
 from yalis.external.model import GPT
 import torch.distributed as dist
+from lightning.fabric.utilities.init import _EmptyInit
+import time
 
 
 def get_model(
@@ -25,7 +27,13 @@ def get_model(
         ), f"Maximum sequence length for this model is {config.block_size}"
         config.block_size = max_sequence_length
     config.tensor_parallel = tensor_parallel
-    model = GPT(config).to(model_dtype)
+
+    # Axonn backend requires an argument to specify the device to initialize parameters on
+    config.init_device = "meta"
+
+    with _EmptyInit():
+        model = GPT(config).to(model_dtype)
+
     if not random_init:
         checkpoint_path = checkpoint_dir / "lit_model.pth"
         load_checkpoint(model, checkpoint_path)


### PR DESCRIPTION
Loading Llama-3.1-70B

Before the change:
Initializing Model took 794.6046226024628 seconds

After the change:
Initializing Model took 312.7900912761688 seconds
