### PR TITLE
Intra head parallelism

### DIFF
--- a/scripts/perlmutter_env.sh
+++ b/scripts/perlmutter_env.sh
@@ -1,0 +1,21 @@
+# for use w/ interactive jobs
+export HF_HOME="${SCRATCH}/.cache/huggingface"
+export TORCHINDUCTOR_CACHE_DIR="${SCRATCH}/.cache/torch_inductor"
+export HF_TRANSFORMERS_CACHE="${HF_HOME}"
+export HF_DATASETS_CACHE="${HF_HOME}/datasets"
+export YALIS_CACHE="${SCRATCH}/yalis/yalis/external"
+module load cudatoolkit/12.4
+module load nccl
+. $SCRATCH/yalis_venv/bin/activate
+NNODES=$SLURM_JOB_NUM_NODES
+GPUS=$(( NNODES * 4 ))
+export MASTER_ADDR=$(hostname)
+export MASTER_PORT=29500
+export WORLD_SIZE=${GPUS}
+export CUDA_DEVICE_MAX_CONNECTIONS=1
+export NCCL_NET_GDR_LEVEL=PHB
+export CUDA_VISIBLE_DEVICES=3,2,1,0
+export NCCL_CROSS_NIC=1
+export NCCL_SOCKET_IFNAME=hsn
+export MPICH_GPU_SUPPORT_ENABLED=0
+export RANK=${SLURM_PROCID}

--- a/yalis/config.py
+++ b/yalis/config.py
@@ -1,6 +1,7 @@
 from typing import Optional, Literal, Tuple
 import os
-
+from packaging.version import Version
+from importlib.metadata import version, PackageNotFoundError
 
 class ModelConfig:
     """
@@ -117,6 +118,12 @@ class InferenceConfig:
         self.metrics = metrics
         self.tp_dims = tp_dims
         self.use_intra_head_parallelism = use_intra_head_parallelism
+        try:
+            pkg_ver = version("torch")
+        except PackageNotFoundError:
+            raise RuntimeError("torch isn’t installed")
+        if Version(pkg_ver) < Version("2.6.0"):
+            raise RuntimeError(f"torch >= 2.6.0 required (found {pkg_ver})")
 
         self._validate()
 

--- a/yalis/config.py
+++ b/yalis/config.py
@@ -89,7 +89,8 @@ class InferenceConfig:
         top_p: Optional[float] = 1.0,
         temperature: Optional[float] = 1.0,
         metrics: bool = False,
-        tp_dims: Optional[Tuple[int, int, int]] = None
+        tp_dims: Optional[Tuple[int, int, int]] = None,
+        use_intra_head_parallelism: bool = False
     ):
         """
         Initialize the inference configuration.
@@ -115,6 +116,7 @@ class InferenceConfig:
         self.top_p = top_p
         self.metrics = metrics
         self.tp_dims = tp_dims
+        self.use_intra_head_parallelism = use_intra_head_parallelism
 
         self._validate()
 

--- a/yalis/engine.py
+++ b/yalis/engine.py
@@ -156,7 +156,13 @@ class LLMEngine:
         t0 = time.time()
         print_rank0(f"Initializing model: {self.model_config.model_name}")
         print_rank0(f"Using precision: {self.model_config.precision}")
-        self.model = get_model(self.model_config.model_path, self.dtype, max_sequence_length=self.inference_config.max_length, random_init=False)
+        self.model = get_model(
+            self.model_config.model_path,
+            self.dtype,
+            max_sequence_length=self.inference_config.max_length,
+            random_init=False,
+            use_intra_head_parallelism=self.inference_config.use_intra_head_parallelism
+        )
         self._make_params_contiguous()
         self.model.set_kv_cache(
             batch_size=self.inference_config.batch_size,

--- a/yalis/external/model.py
+++ b/yalis/external/model.py
@@ -407,7 +407,7 @@ class CausalSelfAttention(nn.Module):
         O = A @ v
         if enable_gqa:
             O = O.view(B, g * hpg, n_q, -1)
-            O = Gather.apply(O, process_group)
+        O = Gather.apply(O, process_group)
         return O
 
 

--- a/yalis/external/model.py
+++ b/yalis/external/model.py
@@ -11,6 +11,7 @@ from typing import Any, Optional, Tuple
 
 import torch
 import torch.nn as nn
+import torch.distributed as dist
 from typing_extensions import Self
 
 try:
@@ -372,6 +373,43 @@ class CausalSelfAttention(nn.Module):
             index.size(0), 1, -1
         )
 
+    def create_upper_mask(self, dim, device):
+        mask = torch.triu(torch.ones(dim, dim, dtype=torch.bool, device=device), diagonal=1)
+        mask = mask.to(torch.float32)
+        mask.masked_fill_(mask.bool(), -float("inf"))
+        return mask
+
+    def intra_head_sdpa(self, q, k, v, attn_mask, process_group, enable_gqa, parallel=True):
+        mask = self.create_upper_mask(q.size(2), q.device) if attn_mask is None else attn_mask
+        if enable_gqa:
+            B, h, n_q, d = q.shape
+            g = k.size(1)
+            hpg = h // g
+            q = q.view(B, g, hpg, n_q, d)
+            B2, g2, n_k, d2 = k.shape
+            k = k.view(B2, g2, 1, n_k, d2)
+            B3, g3, n_v, d3 = v.shape
+            v = v.view(B3, g3, 1, n_v, d3)
+        if parallel:
+            q = Drop.apply(q, process_group).contiguous()
+            k = Drop.apply(k, process_group).contiguous()
+        scale = 1.0 / math.sqrt(self.config.head_size)
+        if enable_gqa:
+            q = q * scale
+            S = torch.einsum("b g h n d, b g o d t -> b g h n t", q, k.mT).clone().contiguous()
+        else:
+            q = q * scale
+            S = (q @ k.mT).clone().contiguous()
+        if parallel:
+            dist.all_reduce(S, op=dist.ReduceOp.SUM, group=process_group)
+        S = S + mask
+        A = torch.nn.functional.softmax(S, dim=-1, dtype=torch.float).to(dtype=q.dtype)
+        O = A @ v
+        if enable_gqa:
+            O = O.view(B, g * hpg, n_q, d)
+        return O
+
+
     def lit_rotary_kv_update_gen(
         self,
         q: torch.Tensor,  # B,nh,1,hs
@@ -409,16 +447,26 @@ class CausalSelfAttention(nn.Module):
 
         k_cache[b_indices, :, token_counter.view(-1), :] = k[:, :, 0, :]
         v_cache[b_indices, :, token_counter.view(-1), :] = v[:, :, 0, :]
-        mask = self.build_mask_from_index(token_counter, t_max=k_cache.size(-2))[
-            :, None, None, :
-        ]
+        mask = self.build_mask_from_index(token_counter, t_max=k_cache.size(-2))
+        #[:, None, None, :]
         
         enable_gqa = q.size(1) != k.size(1)
-        out = torch.nn.functional.scaled_dot_product_attention(
-            q, k_cache, v_cache, attn_mask=mask, enable_gqa=enable_gqa
-        )
-
-        return out
+        if self.config.use_intra_head_parallelism:
+            mask_float = torch.zeros_like(mask, dtype=torch.float32)
+            mask_float = mask_float.masked_fill(~mask, float("-inf"))
+            mask_float = mask_float[:, None, None, :]
+            out = self.intra_head_sdpa(
+                q, k_cache, v_cache, mask_float,
+                ax.comm_handle.inner_intra_layer_parallel_group,
+                enable_gqa, parallel=True
+            )
+            return out
+        else:
+            #print("NOT USING IHP GEN *****")
+            out = torch.nn.functional.scaled_dot_product_attention(
+                q, k_cache, v_cache, attn_mask=mask[:, None, None, :], enable_gqa=enable_gqa
+            )
+            return out
 
     def lit_rotary_kv_update_prefill(
         self,
@@ -452,9 +500,17 @@ class CausalSelfAttention(nn.Module):
         v_cache[:, :, :T, :] = v[:, :, :T, :]
 
         enable_gqa = q.size(1) != k.size(1)
-        out = torch.nn.functional.scaled_dot_product_attention(q, k, v, is_causal=True, enable_gqa=enable_gqa)
-
-        return out
+        if self.config.use_intra_head_parallelism:
+            out = self.intra_head_sdpa(
+                q, k, v, None,
+                ax.comm_handle.inner_intra_layer_parallel_group,
+                enable_gqa, parallel=True
+            )
+            return out
+        else:
+            #print("NOT USING IHP *****")
+            out = torch.nn.functional.scaled_dot_product_attention(q, k, v, is_causal=True, enable_gqa=enable_gqa)
+            return out
 
     def forward(
         self,

--- a/yalis/external/model.py
+++ b/yalis/external/model.py
@@ -447,7 +447,7 @@ class CausalSelfAttention(nn.Module):
         b_indices = torch.arange(B, device=k_cache.device)
         t_indices = token_counter.view(-1)
 
-        if ax.config.G_intra_c > 1:
+        if ax.config.G_intra_c > 1 and  self.config.use_intra_head_parallelism:
             k_cache[b_indices, :, t_indices, :] = Drop.apply(k[:, :, 0, :], ax.comm_handle.inner_intra_layer_parallel_group)
             v_cache[b_indices, :, t_indices, :] = Drop.apply(v[:, :, 0, :], ax.comm_handle.inner_intra_layer_parallel_group)
         else:
@@ -504,7 +504,7 @@ class CausalSelfAttention(nn.Module):
 
         q, k = roped_tensors
         
-        if ax.config.G_intra_c > 1:
+        if ax.config.G_intra_c > 1 and  self.config.use_intra_head_parallelism:
             k_cache[:, :, :T, :] = Drop.apply(k[:, :, :T, :], ax.comm_handle.inner_intra_layer_parallel_group)
             v_cache[:, :, :T, :] = Drop.apply(v[:, :, :T, :], ax.comm_handle.inner_intra_layer_parallel_group)
         else:

--- a/yalis/external/model.py
+++ b/yalis/external/model.py
@@ -698,11 +698,10 @@ class CausalSelfAttention(nn.Module):
 
         if self.config.use_intra_head_parallelism:
             assert k_shape[-1] % ax.config.G_intra_c == 0
-            k_shape[-1] //= ax.config.G_intra_c
+            k_shape = k_shape[:-1] + (k_shape[-1] // ax.config.G_intra_c,)
 
             assert v_shape[-1] % ax.config.G_intra_c == 0
-            v_shape[-1] //= ax.config.G_intra_c
-
+            v_shape = v_shape[:-1] + (v_shape[-1] // ax.config.G_intra_c,)
         return KVCache(k_shape, v_shape, device=device, dtype=dtype)
 
 

--- a/yalis/external/model.py
+++ b/yalis/external/model.py
@@ -455,6 +455,7 @@ class CausalSelfAttention(nn.Module):
             mask_float = torch.zeros_like(mask, dtype=torch.float32)
             mask_float = mask_float.masked_fill(~mask, float("-inf"))
             mask_float = mask_float[:, None, None, :]
+            mask_float = mask_float.unsqueeze(1)
             out = self.intra_head_sdpa(
                 q, k_cache, v_cache, mask_float,
                 ax.comm_handle.inner_intra_layer_parallel_group,

--- a/yalis/external/model.py
+++ b/yalis/external/model.py
@@ -392,7 +392,7 @@ class CausalSelfAttention(nn.Module):
             v = v.view(B3, g3, 1, n_v, d3)
         if parallel:
             q = Drop.apply(q, process_group).contiguous()
-            k = Drop.apply(k, process_group).contiguous()
+            #k = Drop.apply(k, process_group).contiguous()
         scale = 1.0 / math.sqrt(self.config.head_size)
         if enable_gqa:
             q = q * scale
@@ -406,7 +406,8 @@ class CausalSelfAttention(nn.Module):
         A = torch.nn.functional.softmax(S, dim=-1, dtype=torch.float).to(dtype=q.dtype)
         O = A @ v
         if enable_gqa:
-            O = O.view(B, g * hpg, n_q, d)
+            O = O.view(B, g * hpg, n_q, -1)
+            O = Gather.apply(O, process_group)
         return O
 
 
@@ -444,9 +445,14 @@ class CausalSelfAttention(nn.Module):
 
         B = k_cache.size(0)
         b_indices = torch.arange(B, device=k_cache.device)
+        t_indices = token_counter.view(-1)
 
-        k_cache[b_indices, :, token_counter.view(-1), :] = k[:, :, 0, :]
-        v_cache[b_indices, :, token_counter.view(-1), :] = v[:, :, 0, :]
+        if ax.config.G_intra_c > 1:
+            k_cache[b_indices, :, t_indices, :] = Drop.apply(k[:, :, 0, :], ax.comm_handle.inner_intra_layer_parallel_group)
+            v_cache[b_indices, :, t_indices, :] = Drop.apply(v[:, :, 0, :], ax.comm_handle.inner_intra_layer_parallel_group)
+        else:
+            k_cache[b_indices, :, t_indices, :] = k[:, :, 0, :]
+            v_cache[b_indices, :, t_indices, :] = v[:, :, 0, :]
         mask = self.build_mask_from_index(token_counter, t_max=k_cache.size(-2))
         #[:, None, None, :]
         
@@ -497,11 +503,16 @@ class CausalSelfAttention(nn.Module):
             roped_tensors.append(roped)
 
         q, k = roped_tensors
-        k_cache[:, :, :T, :] = k[:, :, :T, :]
-        v_cache[:, :, :T, :] = v[:, :, :T, :]
+        
+        if ax.config.G_intra_c > 1:
+            k_cache[:, :, :T, :] = Drop.apply(k[:, :, :T, :], ax.comm_handle.inner_intra_layer_parallel_group)
+            v_cache[:, :, :T, :] = Drop.apply(v[:, :, :T, :], ax.comm_handle.inner_intra_layer_parallel_group)
+        else:
+            k_cache[:, :, :T, :] = k[:, :, :T, :]
+            v_cache[:, :, :T, :] = v[:, :, :T, :]
 
         enable_gqa = q.size(1) != k.size(1)
-        if self.config.use_intra_head_parallelism:
+        if False: #self.config.use_intra_head_parallelism:
             out = self.intra_head_sdpa(
                 q, k, v, None,
                 ax.comm_handle.inner_intra_layer_parallel_group,
@@ -684,6 +695,13 @@ class CausalSelfAttention(nn.Module):
                     max_seq_length,
                     rope_cache_length + self.config.head_size - self.config.rope_n_elem,
                 )
+
+        if self.config.use_intra_head_parallelism:
+            assert k_shape[-1] % ax.config.G_intra_c == 0
+            k_shape[-1] //= ax.config.G_intra_c
+
+            assert v_shape[-1] % ax.config.G_intra_c == 0
+            v_shape[-1] //= ax.config.G_intra_c
 
         return KVCache(k_shape, v_shape, device=device, dtype=dtype)
 

--- a/yalis/model.py
+++ b/yalis/model.py
@@ -14,6 +14,7 @@ def get_model(
     max_sequence_length=None,
     random_init=False,
     device="cuda",
+    use_intra_head_parallelism=False
 ):
     tensor_parallel = dist.get_world_size() > 1
     if tensor_parallel and dist.get_rank() == 0:
@@ -26,6 +27,7 @@ def get_model(
         ), f"Maximum sequence length for this model is {config.block_size}"
         config.block_size = max_sequence_length
     config.tensor_parallel = tensor_parallel
+    config.use_intra_head_parallelism = use_intra_head_parallelism
 
     with _EmptyInit(enabled=(not random_init)):
         model = GPT(config).to(model_dtype)


### PR DESCRIPTION
***WIP PR:***

To use, when creating `InferenceConfig`, set `use_intra_head_parallelism=True`, ex:
`InferenceConfig(..., use_intra_head_parallelism=True)`

`intra_head_sdpa` also takes `parallel: bool` as an argument (`True` by default, currently not configurable as I'm just using it for debugging). Setting this to `False` will result in `intra_head_sdpa` functioning as a naïve implementation of attention, without any intra-head parallelism.

The implementation works for MHA and GQA, for prefill and for generate phases.

For MHA, performance is close to Torch's SDPA (~92% of Torch's throughput for llama2-7b with a batch of 1).

***However***, for GQA with `parallel=True`, if Torch compile is turned on, the `dist.all_reduce` call will complain that "tensors must be contiguous" (and so GQA+IHP cannot be used with Torch compile). This is despite attempts to force the tensors to be contiguous with `contiguous()`, `.clone()`, and `.copy_()`. If Torch compile is turned off, the correct outputs are produced, but this is of course very slow.

Currently investigating alternative PyTorch versions...