### PR TITLE
Intra head perf opt

### DIFF
--- a/yalis/external/model.py
+++ b/yalis/external/model.py
@@ -407,7 +407,7 @@ class CausalSelfAttention(nn.Module):
         O = A @ v
         if enable_gqa:
             O = O.view(B, g * hpg, n_q, -1)
-            O = Gather.apply(O, process_group)
+        O = Gather.apply(O, process_group)
         return O
 
 

--- a/yalis/external/model.py
+++ b/yalis/external/model.py
@@ -447,7 +447,7 @@ class CausalSelfAttention(nn.Module):
         b_indices = torch.arange(B, device=k_cache.device)
         t_indices = token_counter.view(-1)
 
-        if ax.config.G_intra_c > 1:
+        if ax.config.G_intra_c > 1 and  self.config.use_intra_head_parallelism:
             k_cache[b_indices, :, t_indices, :] = Drop.apply(k[:, :, 0, :], ax.comm_handle.inner_intra_layer_parallel_group)
             v_cache[b_indices, :, t_indices, :] = Drop.apply(v[:, :, 0, :], ax.comm_handle.inner_intra_layer_parallel_group)
         else:
@@ -504,7 +504,7 @@ class CausalSelfAttention(nn.Module):
 
         q, k = roped_tensors
         
-        if ax.config.G_intra_c > 1:
+        if ax.config.G_intra_c > 1 and  self.config.use_intra_head_parallelism:
             k_cache[:, :, :T, :] = Drop.apply(k[:, :, :T, :], ax.comm_handle.inner_intra_layer_parallel_group)
             v_cache[:, :, :T, :] = Drop.apply(v[:, :, :T, :], ax.comm_handle.inner_intra_layer_parallel_group)
         else:

--- a/yalis/external/model.py
+++ b/yalis/external/model.py
@@ -698,11 +698,10 @@ class CausalSelfAttention(nn.Module):
 
         if self.config.use_intra_head_parallelism:
             assert k_shape[-1] % ax.config.G_intra_c == 0
-            k_shape[-1] //= ax.config.G_intra_c
+            k_shape = k_shape[:-1] + (k_shape[-1] // ax.config.G_intra_c,)
 
             assert v_shape[-1] % ax.config.G_intra_c == 0
-            v_shape[-1] //= ax.config.G_intra_c
-
+            v_shape = v_shape[:-1] + (v_shape[-1] // ax.config.G_intra_c,)
         return KVCache(k_shape, v_shape, device=device, dtype=dtype)
 
 

--- a/yalis/external/model.py
+++ b/yalis/external/model.py
@@ -392,7 +392,7 @@ class CausalSelfAttention(nn.Module):
             v = v.view(B3, g3, 1, n_v, d3)
         if parallel:
             q = Drop.apply(q, process_group).contiguous()
-            k = Drop.apply(k, process_group).contiguous()
+            #k = Drop.apply(k, process_group).contiguous()
         scale = 1.0 / math.sqrt(self.config.head_size)
         if enable_gqa:
             q = q * scale
@@ -406,7 +406,8 @@ class CausalSelfAttention(nn.Module):
         A = torch.nn.functional.softmax(S, dim=-1, dtype=torch.float).to(dtype=q.dtype)
         O = A @ v
         if enable_gqa:
-            O = O.view(B, g * hpg, n_q, d)
+            O = O.view(B, g * hpg, n_q, -1)
+            O = Gather.apply(O, process_group)
         return O
 
 
@@ -444,9 +445,14 @@ class CausalSelfAttention(nn.Module):
 
         B = k_cache.size(0)
         b_indices = torch.arange(B, device=k_cache.device)
+        t_indices = token_counter.view(-1)
 
-        k_cache[b_indices, :, token_counter.view(-1), :] = k[:, :, 0, :]
-        v_cache[b_indices, :, token_counter.view(-1), :] = v[:, :, 0, :]
+        if ax.config.G_intra_c > 1:
+            k_cache[b_indices, :, t_indices, :] = Drop.apply(k[:, :, 0, :], ax.comm_handle.inner_intra_layer_parallel_group)
+            v_cache[b_indices, :, t_indices, :] = Drop.apply(v[:, :, 0, :], ax.comm_handle.inner_intra_layer_parallel_group)
+        else:
+            k_cache[b_indices, :, t_indices, :] = k[:, :, 0, :]
+            v_cache[b_indices, :, t_indices, :] = v[:, :, 0, :]
         mask = self.build_mask_from_index(token_counter, t_max=k_cache.size(-2))
         #[:, None, None, :]
         
@@ -497,11 +503,16 @@ class CausalSelfAttention(nn.Module):
             roped_tensors.append(roped)
 
         q, k = roped_tensors
-        k_cache[:, :, :T, :] = k[:, :, :T, :]
-        v_cache[:, :, :T, :] = v[:, :, :T, :]
+        
+        if ax.config.G_intra_c > 1:
+            k_cache[:, :, :T, :] = Drop.apply(k[:, :, :T, :], ax.comm_handle.inner_intra_layer_parallel_group)
+            v_cache[:, :, :T, :] = Drop.apply(v[:, :, :T, :], ax.comm_handle.inner_intra_layer_parallel_group)
+        else:
+            k_cache[:, :, :T, :] = k[:, :, :T, :]
+            v_cache[:, :, :T, :] = v[:, :, :T, :]
 
         enable_gqa = q.size(1) != k.size(1)
-        if self.config.use_intra_head_parallelism:
+        if False: #self.config.use_intra_head_parallelism:
             out = self.intra_head_sdpa(
                 q, k, v, None,
                 ax.comm_handle.inner_intra_layer_parallel_group,
@@ -684,6 +695,13 @@ class CausalSelfAttention(nn.Module):
                     max_seq_length,
                     rope_cache_length + self.config.head_size - self.config.rope_n_elem,
                 )
+
+        if self.config.use_intra_head_parallelism:
+            assert k_shape[-1] % ax.config.G_intra_c == 0
+            k_shape[-1] //= ax.config.G_intra_c
+
+            assert v_shape[-1] % ax.config.G_intra_c == 0
+            v_shape[-1] //= ax.config.G_intra_c
 
         return KVCache(k_shape, v_shape, device=device, dtype=dtype)
 


### PR DESCRIPTION
- Saves G_intra_c times memory in the kv_cache
- faster than the previous implementation of intra-head. 
- slower than w/o intra-head but more memory efficient.

## Summary of changes

1. kv-cache stores only a subset of the heads (save memory)
2. as soon as a key/value is generated drop it’s heads and save it into the kv-cache
3. during intra-head-sdpa do NOT drop the heads of k (since the kv-cache is already divided)
4. Gather O at the end since the produced O is divided
5. Disable intra-head sdpa in the prefill stage. We compute on all heads, but divide and store heads.

