### PR TITLE
Fix: Torch compile with latest flash attention fix

### DIFF
--- a/yalis/attention/flash.py
+++ b/yalis/attention/flash.py
@@ -3,6 +3,26 @@ import torch
 from typing import Sequence, Optional, Union
 from .registry import register_attention
 from .update_kv_cache import update_paged_kv_cache
+from flash_attn.ops.triton.rotary import apply_rotary
+
+
+# A recent change (Commit a9a3170) added a wrap_triton call to the rotary kernel invocation
+# Torch compile requires this call to be inside a triton_op, otherwise compilation breaks
+# Ideally, this should be fixed in the flash attention repo but for now, this workaround works
+# TODO: Once flash attention fixes this, remove this
+@torch.library.triton_op("yalis::flash_apply_rotary", mutates_args=()) 
+def flash_apply_rotary(x: torch.Tensor, 
+                        rotary_cos: Optional[torch.Tensor] = None, 
+                        rotary_sin: Optional[torch.Tensor] = None, 
+                        token_counter: Optional[torch.Tensor] = None) -> torch.Tensor:
+    """
+    Applies rotary embeddings to the input tensor
+    """
+    return apply_rotary(x, 
+                        rotary_cos,
+                        rotary_sin,
+                        token_counter)
+
 
 
 # here we are registering the flash_attn_with_kv_cache kernel as a custom pytorch op 

--- a/yalis/external/model.py
+++ b/yalis/external/model.py
@@ -25,7 +25,7 @@ from copy import deepcopy
 from axonn import axonn as ax
 from axonn.intra_layer.communication import Drop, Gather
 from kvcache_manager import KVCacheManager
-from flash_attn.ops.triton.rotary import apply_rotary
+from yalis.attention.flash import flash_apply_rotary as apply_rotary
 from yalis.attention.backends import AttentionBackend
 from yalis.attention.masking import create_causal_block_mask_for_flex_attention
 

--- a/yalis/model.py
+++ b/yalis/model.py
@@ -1,5 +1,5 @@
 import torch
-from litgpt.model import Config
+from yalis.external.config import Config
 from pathlib import Path
 import sys
 from yalis.external.litgpt_utils import load_checkpoint, _EmptyInit


### PR DESCRIPTION
This PR fixes torch compile compatibility with the latest flash attention 
A recent change in the rotary op breaks torch compile and a workaround fix has been tested
Ideally, the fix should be in FlashAttention repo and once they make the change, we can remove our workaround