### PR TITLE
r-scaling

### DIFF
--- a/yalis/external/model.py
+++ b/yalis/external/model.py
@@ -380,10 +380,28 @@ class CausalSelfAttention(nn.Module):
             # currently attention is duplicated across the column tensor parallel group
             self.config = deepcopy(self.config)
             attention_world_size = ax.config.G_intra_r
+            self.duplicating_kv = attention_world_size > config.n_query_groups
+            if self.duplicating_kv:
+                self.duplication_degree = attention_world_size // config.n_query_groups
+            else:
+                self.duplication_degree = 1
             assert self.config.n_head % attention_world_size == 0
+            # saving originals
+            self.total_n_head = self.config.n_head
+            self.total_n_query_groups = self.config.n_query_groups
+            # q per rank
             self.config.n_head //= attention_world_size
-            assert self.config.n_query_groups % attention_world_size == 0
-            self.config.n_query_groups //= attention_world_size
+            if self.duplicating_kv:
+                self.config.n_query_groups = 1
+                self.attn.duplicating_kv = True
+                self.attn.total_n_head = self.total_n_head
+                self.attn.total_n_query_groups = self.total_n_query_groups
+                self.attn.duplication_degree = self.duplication_degree
+                self.attn.head_size = self.config.head_size
+                self.attn.q_per_rank = self.config.n_head
+            else:
+                assert self.config.n_query_groups % attention_world_size == 0
+                self.config.n_query_groups //= attention_world_size
 
     def forward(
         self,

--- a/yalis/external/model.py
+++ b/yalis/external/model.py
@@ -382,11 +382,12 @@ class CausalSelfAttention(nn.Module):
             attention_world_size = ax.config.G_intra_r
             self.duplicating_kv = attention_world_size > config.n_query_groups
             if self.duplicating_kv:
+                assert attention_world_size % config.n_query_groups == 0
                 self.duplication_degree = attention_world_size // config.n_query_groups
             else:
                 self.duplication_degree = 1
             assert self.config.n_head % attention_world_size == 0
-            # saving originals
+            # storing number of global heads in the entire model
             self.total_n_head = self.config.n_head
             self.total_n_query_groups = self.config.n_query_groups
             # q per rank

--- a/yalis/tensor_parallel/linear.py
+++ b/yalis/tensor_parallel/linear.py
@@ -270,8 +270,6 @@ class TPLinear(torch.nn.Module):
             ), "This is neither a full checkpoint nor a sharded checkpoint"
 
             if is_full_weight_matrix and getattr(self, "duplicating_kv", False):
-                #print("THE SCARY CASE!!!!")
-                #world  = dist.get_world_size(self.outer_group)
                 rank = dist.get_rank(self.outer_group)
                 hs = self.head_size
                 q_per_rank = self.q_per_rank
@@ -313,6 +311,8 @@ class TPLinear(torch.nn.Module):
                 state_dict[prefix + "weight"] = weight
 
         if self.bias is not None:
+            if getattr(self, "duplicating_kv", False):
+                raise NotImplementedError("There is currently no support for scaling the R dimension > #kv heads when using a model with bias")
             bias = (
                 state_dict[prefix + "bias"] if prefix + "bias" in state_dict else None
             )

--- a/yalis/tensor_parallel/linear.py
+++ b/yalis/tensor_parallel/linear.py
@@ -153,11 +153,14 @@ class TPLinear(torch.nn.Module):
         # in_features should be divisible by inner_group_size
         assert in_features % self.inner_group_size == 0
         # in_features should be divisible by inner_group_size
-        assert out_features % self.outer_group_size == 0
+        ###assert out_features % self.outer_group_size == 0
         # local_in_features - this is the number of in_features on each GPU
         self.local_in_features = divide(in_features, self.inner_group_size)
         # local_out_features - this is the number of out_features on each GPU
-        self.local_out_features = divide(out_features, self.outer_group_size)
+        if out_features % self.outer_group_size == 0:
+            self.local_out_features = divide(out_features, self.outer_group_size)
+        else:
+            self.local_out_features = math.ceil(out_features / self.outer_group_size)
         # initialize the weight matrix and grab the local slice for each GPU
         initial_params = initialize_params(
             out_features,
@@ -266,7 +269,38 @@ class TPLinear(torch.nn.Module):
                 is_full_weight_matrix or is_sharded_weight_matrix
             ), "This is neither a full checkpoint nor a sharded checkpoint"
 
-            if is_full_weight_matrix:
+            if is_full_weight_matrix and getattr(self, "duplicating_kv", False):
+                #print("THE SCARY CASE!!!!")
+                #world  = dist.get_world_size(self.outer_group)
+                rank = dist.get_rank(self.outer_group)
+                hs = self.head_size
+                q_per_rank = self.q_per_rank
+                q_per_kv = self.total_n_head // self.total_n_query_groups
+                blk = q_per_kv + 2
+                q_rows = []
+                groups = set()
+                for h in range(rank * q_per_rank, (rank + 1) * q_per_rank):
+                    g = h // q_per_kv
+                    groups.add(g)
+                    local_q = h % q_per_kv
+                    row0 = (g * blk + local_q) * hs
+                    q_rows.extend(range(row0, row0 + hs))
+                kv_rows = []
+                for g in groups:
+                    base = g * blk * hs + q_per_kv * hs
+                    kv_rows.extend(range(base, base + hs))
+                    kv_rows.extend(range(base + hs, base + 2 * hs))
+                local_rows = q_rows + kv_rows
+                weight = weight.contiguous()
+                weight = weight[local_rows, :].contiguous()
+                state_dict[prefix + "weight"] = weight
+                if self.weight.shape != weight.shape:
+                    self.weight = torch.nn.Parameter(
+                        torch.empty_like(weight, device="cuda"),
+                        requires_grad=True
+                    )
+                self.local_out_features = weight.size(0)
+            elif is_full_weight_matrix:
                 out_features_group, in_features_group = (
                     self.outer_group,
                     self.inner_group,
@@ -274,8 +308,9 @@ class TPLinear(torch.nn.Module):
                 weight = extract_local_params_from_full_params(
                     weight, out_features_group, in_features_group
                 )
-
-            state_dict[prefix + "weight"] = weight
+                state_dict[prefix + "weight"] = weight
+            else:
+                state_dict[prefix + "weight"] = weight
 
         if self.bias is not None:
             bias = (


### PR DESCRIPTION
In GQA scaling the R dimension was limited by the number of KV heads. This relaxes that requirement by allowing KV heads to be duplicated if R > # KV heads. Initial results seem good.