### PR TITLE
correctly import find_multiple from litgpt version >= 0.5.9

### DIFF
--- a/yalis/external/config.py
+++ b/yalis/external/config.py
@@ -8,8 +8,17 @@ from typing import Any, Literal, Optional, Type, Union
 import torch
 import yaml
 from typing_extensions import Self
-from litgpt.utils import find_multiple
 
+from packaging.version import Version
+from importlib.metadata import version, PackageNotFoundError
+try:
+    litgpt_version = version("litgpt")
+except:
+    raise RuntimeError("litgpt isn't installed!")
+if Version(litgpt_version) >= Version("0.5.9"):
+    from litgpt.config import find_multiple
+else:
+    from litgpt.utils import find_multiple
 
 @dataclass
 class Config:


### PR DESCRIPTION
litgpt moved `find_multiple` from utils.py to config.py:
https://github.com/Lightning-AI/litgpt/pull/2034

in yalis/external/config.py we do:
`from litgpt.utils import find_multiple`

this results in the import failing for litgpt versions >= 0.5.9 (the latest version).
the PR addresses this