### PR TITLE
build fix for no torch when installing

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,0 +1,7 @@
+[build-system]
+requires = [
+  "setuptools>=61",
+  "wheel",
+  "torch>=2.0"
+]
+build-backend = "setuptools.build_meta"


### PR DESCRIPTION
Was reinstalling on Delta w/ the build instructions in the README, resulting in:

`ModuleNotFoundError: No module named 'torch'`

after doing `pip install -e .`

This seems to stem from `from torch.utils.cpp_extension import BuildExtension, CppExtension` in setup.py. Adding this minimal pyproject.toml fixes the issue and it installs correctly.