### PR TITLE
Safetensors based saving and loading checkpoints instead of .pth

### DIFF
--- a/tests/basic_correctness/conftest.py
+++ b/tests/basic_correctness/conftest.py
@@ -116,10 +116,10 @@ def hf_model(model_id, dtype, attn_backend, device):
     model = AutoModelForCausalLM.from_pretrained(
         model_id,
         attn_implementation=attn_backend.hf,
-        torch_dtype=dtype.hf,
-        device_map=None,
+        dtype=dtype.hf,
+        device_map="auto",
         trust_remote_code=True,
-    ).to(device)
+    )
     model.eval()
     return model
 

--- a/yalis/external/convert_hf_checkpoint.py
+++ b/yalis/external/convert_hf_checkpoint.py
@@ -186,6 +186,7 @@ def copy_weights_hf_llama(
             1, len(hf_weights) + len(qkv_weights)
         )
 
+    transformer_wte_weight = None
     for name, param in hf_weights.items():
         if "model.layers" in name:
             from_name, l = layer_template(name, 2)
@@ -281,7 +282,7 @@ def copy_weights_hf_llama(
 
         if saver is not None:
             # For the tensors that have a to mapping, we use the same store early principle
-            # we store the reference and then we delete the loaded tensor from teh RAM
+            # we store the reference and then we delete the loaded tensor from the RAM
             param_saved = saver.store_early(to_name, param)
             del param
             gc.collect()

--- a/yalis/external/convert_hf_checkpoint.py
+++ b/yalis/external/convert_hf_checkpoint.py
@@ -18,10 +18,11 @@ from lightning.fabric.utilities.load import (
 from config import Config
 from litgpt.utils import (
     extend_checkpoint_dir,
-    incremental_save,
     lazy_load,
     save_config,
+    # incremental_save,
 )
+from safetensor_saver import incremental_save
 
 
 def copy_weights_gpt_neox(
@@ -69,7 +70,7 @@ def copy_weights_gpt_neox(
             to_name = weight_map[name]
         param = load_param(param, name, dtype, verbose=debug_mode)
         if saver is not None:
-            param = saver.store_early(param)
+            param = saver.store_early(to_name, param)
         state_dict[to_name] = param
 
         if progress_per_file is not None:
@@ -127,7 +128,7 @@ def copy_weights_falcon(
             to_name = weight_map[name]
         param = load_param(param, name, dtype, verbose=debug_mode)
         if saver is not None:
-            param = saver.store_early(param)
+            param = saver.store_early(to_name, param)
         state_dict[to_name] = param
         if progress_per_file is not None:
             pbar.update(progress_per_file)
@@ -223,7 +224,9 @@ def copy_weights_hf_llama(
                 cycled = [t for group in zip(qs, ks, vs) for t in group]
                 qkv = torch.cat(cycled)
 
-                qkv_ref = saver.store_early(qkv)
+                qkv_ref = saver.store_early(
+                    f"transformer.h.{l}.attn.attn.weight", qkv
+                )
                 # store early returns a reference to the actual memory stored in the disk
                 # freeing up space from the RAM
                 state_dict[f"transformer.h.{l}.attn.attn.weight"] = qkv_ref
@@ -251,7 +254,9 @@ def copy_weights_hf_llama(
                 gate_up_proj = torch.stack(
                     (gate_proj, up_proj), dim=1
                 ).reshape(2 * gate_proj.size(0), -1)
-                gate_up_proj_ref = saver.store_early(gate_up_proj)
+                gate_up_proj_ref = saver.store_early(
+                    f"transformer.h.{l}.mlp.gate_up_proj.weight", gate_up_proj
+                )
                 state_dict[f"transformer.h.{l}.mlp.gate_up_proj.weight"] = (
                     gate_up_proj_ref
                 )
@@ -270,10 +275,14 @@ def copy_weights_hf_llama(
         else:
             to_name = weight_map[name]
         param = load_param(param, name, dtype, verbose=debug_mode)
+
+        if to_name == "transformer.wte.weight":
+            transformer_wte_weight = param
+
         if saver is not None:
             # For the tensors that have a to mapping, we use the same store early principle
             # we store the reference and then we delete the loaded tensor from teh RAM
-            param_saved = saver.store_early(param)
+            param_saved = saver.store_early(to_name, param)
             del param
             gc.collect()
             state_dict[to_name] = param_saved
@@ -285,7 +294,13 @@ def copy_weights_hf_llama(
             pbar.update(progress_per_file)
 
     if "lm_head.weight" not in state_dict:
-        state_dict["lm_head.weight"] = state_dict["transformer.wte.weight"]
+        if transformer_wte_weight is not None:
+            param_saved = saver.store_early(
+                "lm_head.weight", transformer_wte_weight
+            )
+            del transformer_wte_weight
+            gc.collect()
+            state_dict["lm_head.weight"] = param_saved
 
     # convert separate gate proj and up proj into one tensor
     for i, (gate_proj, up_proj) in list(gate_up_proj_weights.items()):
@@ -380,6 +395,7 @@ def copy_weights_gemma_2(
             1, len(hf_weights) + len(qkv_weights)
         )
 
+    transformer_wte_weight = None
     for name, param in hf_weights.items():
         if "model.layers" in name:
             from_name, l_idx = layer_template(name, 2)
@@ -398,16 +414,26 @@ def copy_weights_gemma_2(
             to_name = to_name.format(l_idx)
         else:
             to_name = weight_map[name]
+
+        if to_name == "transformer.wte.weight":
+            transformer_wte_weight = param
+
         param = load_param(param, name, dtype)
         if saver is not None:
-            param = saver.store_early(param)
+            param = saver.store_early(to_name, param)
         state_dict[to_name] = param
 
         if progress_per_file is not None:
             pbar.update(progress_per_file)
 
     if "lm_head.weight" not in state_dict:
-        state_dict["lm_head.weight"] = state_dict["transformer.wte.weight"]
+        if transformer_wte_weight is not None:
+            param_saved = saver.store_early(
+                "lm_head.weight", transformer_wte_weight
+            )
+            del transformer_wte_weight
+            gc.collect()
+            state_dict["lm_head.weight"] = param_saved
 
     # convert separate q, k, v matrices into an interleaved qkv
     for i in list(qkv_weights):
@@ -555,7 +581,7 @@ def copy_weights_phi(
             to_name = weight_map[name]
         param = load_param(param, name, dtype, verbose=debug_mode)
         if saver is not None:
-            param = saver.store_early(param)
+            param = saver.store_early(to_name, param)
         state_dict[to_name] = param
         if progress_per_file is not None:
             pbar.update(progress_per_file)
@@ -735,7 +761,11 @@ def convert_hf_checkpoint(
             f"Expected {str(checkpoint_dir)!r} to contain .bin files"
         )
 
-    with incremental_save(checkpoint_dir / "lit_model.pth") as saver:
+    save_dir = checkpoint_dir / "yalis_checkpoints"
+    os.makedirs(save_dir, exist_ok=True)
+
+    # with incremental_save(checkpoint_dir / "lit_model.pth") as saver:
+    with incremental_save(save_dir) as saver:
         # for checkpoints that split the QKV across several files, we need to keep all the bin files
         # open, so we use `ExitStack` to close them all together at the end
 

--- a/yalis/external/litgpt_utils.py
+++ b/yalis/external/litgpt_utils.py
@@ -7,6 +7,9 @@ from typing_extensions import override
 from pathlib import Path
 from yalis.utils import print_rank0
 from tqdm.auto import tqdm
+import warnings
+
+warnings.filterwarnings("once", category=DeprecationWarning)
 
 
 # From https://lernapparat.de/faster-model-init by Thomas Viehmann
@@ -43,9 +46,13 @@ class _EmptyInit(TorchFunctionMode):
         return func(*args, **kwargs)
 
 
-def load_checkpoint(
+def load_litgpt_checkpoint(
     model: nn.Module, checkpoint_path: Path, strict: bool = True
 ) -> None:
+    warnings.warn(
+        "Loading .pth checkpoints is deprecated. Move to safetensors instead.",
+        DeprecationWarning,
+    )
     print_rank0(f"Loading checkpoint from {checkpoint_path}")
     state_dict = lazy_load(checkpoint_path)
     state_dict = state_dict.get("model", state_dict)

--- a/yalis/external/safetensor_saver.py
+++ b/yalis/external/safetensor_saver.py
@@ -1,0 +1,197 @@
+import os
+import json
+from typing import Dict, Iterable, Tuple, Optional, Any
+import torch
+from safetensors.torch import save_file as save_safetensors
+from dataclasses import dataclass
+
+
+@dataclass(frozen=True)
+class _AlreadyStored:
+    name: str
+
+
+# SafeTensor Shard Writer
+class _SafeTensorShardWriter:
+    def __init__(
+        self,
+        out_dir: str,
+        filename_prefix: str = "model",
+        max_shard_size_bytes: int = 4 * (1024**3),  # 4 GB default
+        per_shard_metadata: Optional[Dict[str, str]] = None,
+        make_contiguous: bool = True,
+    ):
+        os.makedirs(out_dir, exist_ok=True)
+        self.out_dir = out_dir
+        self.prefix = filename_prefix
+        self.max_shard = max_shard_size_bytes
+        self.meta = per_shard_metadata or {}
+        self.make_contiguous = make_contiguous
+
+        self.buf: Dict[str, torch.Tensor] = {}
+        self.buf_size = 0
+        self.weight_map: Dict[str, str] = {}
+        self.total_size = 0
+        self.shard_idx = 0
+        self.closed = False
+        self.per_tensor_overhead = 1024  # ~1KB JSON/name fudge
+
+    def _next_shard_name(self) -> str:
+        self.shard_idx += 1
+        return f"{self.prefix}-{self.shard_idx:05d}.safetensors"
+
+    def _flush(self):
+        if not self.buf:
+            return
+        shard_name = self._next_shard_name()
+        shard_path = os.path.join(self.out_dir, shard_name)
+        # write atomically
+        save_safetensors(self.buf, shard_path, metadata=self.meta)
+        for k in self.buf.keys():
+            self.weight_map[k] = shard_name
+        self.buf.clear()
+        self.buf_size = 0
+
+    def add(self, name: str, t: torch.Tensor):
+        if self.closed:
+            raise RuntimeError("Shard writer already closed")
+
+        t = t.detach()
+        if t.device.type != "cpu":
+            t = t.to("cpu", copy=False)
+        if not t.is_contiguous() and self.make_contiguous:
+            t = t.contiguous()
+
+        nbytes = t.element_size() * t.numel()
+        est = nbytes + self.per_tensor_overhead
+
+        self.buf[name] = t
+        self.buf_size += est
+        self.total_size += nbytes
+
+        if self.buf_size > self.max_shard:
+            self._flush()
+
+    def close(self):
+        if self.closed:
+            return
+        self._flush()
+        self.closed = True
+        index = {
+            "metadata": {},
+            "weight_map": self.weight_map,
+            "total_size": self.total_size,
+            "shard_count": self.shard_idx,
+            "prefix": self.prefix,
+        }
+        with open(
+            os.path.join(
+                self.out_dir, f"{self.prefix}.safetensors.index.json"
+            ),
+            "w",
+        ) as f:
+            json.dump(index, f, indent=2)
+
+
+# Incremental SafeTensor Saver
+class incremental_save:
+    """
+    Usage:
+        with incremental_save(out_dir, max_shard_size_bytes=8*(1024**3)) as saver: # noqa: E501
+            for name, p in model.named_parameters():  # you MUST know `name`
+                saver.store_early(name, p)            # adds to shard, flushes as needed
+            for name, b in model.named_buffers():
+                saver.store_early(name, b)
+            saver.save()  # finalize (writes index); `obj` is optional
+    """
+
+    def __init__(
+        self,
+        name: str,
+        *,
+        max_shard_size_bytes: int = 4 * (1024**3),
+        per_shard_metadata: Optional[Dict[str, str]] = None,
+        filename_prefix: str = "model",
+        make_contiguous: bool = True,
+    ):
+        out_dir = (
+            name
+            if os.path.isdir(name) or name.endswith("/")
+            else os.path.dirname(name) or "."
+        )
+        self._writer = _SafeTensorShardWriter(
+            out_dir=out_dir,
+            filename_prefix=filename_prefix,
+            max_shard_size_bytes=max_shard_size_bytes,
+            per_shard_metadata=per_shard_metadata,
+            make_contiguous=make_contiguous,
+        )
+        self.has_saved = False
+        self._committed_names: set[str] = set()
+
+    def __enter__(self):
+        return self
+
+    def _store_early(self, tensor: torch.Tensor):
+        raise TypeError("store_early expects (name: str, tensor: Tensor)")
+
+    def store_early(self, name: str, tensor: torch.Tensor):
+        if not isinstance(name, str) or not isinstance(tensor, torch.Tensor):
+            raise TypeError("store_early expects (name: str, tensor: Tensor)")
+        # Allows overwriting of the same name so that last mapping is respected
+
+        self._writer.add(name, tensor)  # may flush the shard
+        self._committed_names.add(name)
+        return _AlreadyStored(name)
+
+    def _iter_named_tensors(
+        self, obj: Any
+    ) -> Iterable[Tuple[str, torch.Tensor]]:
+        # Optional: allow adding late extras via a mapping in save(obj)
+        if isinstance(obj, dict):
+            for k, v in obj.items():
+                if k in self._committed_names:
+                    continue  # already written via store_early
+                if isinstance(v, torch.Tensor):
+                    yield k, v
+            return
+        # Optional: iterable of (name, tensor)
+        try:
+            iterator = iter(obj)
+            first = next(iterator)
+        except TypeError:
+            raise TypeError(
+                "save(obj) expects a mapping or iterable of (name, tensor)"
+            )
+        except StopIteration:
+            return
+
+        def _emit(pair):
+            k, v = pair
+            if k not in self._committed_names and isinstance(v, torch.Tensor):
+                yield k, v
+
+        for out in _emit(first):
+            yield out
+        for pair in iterator:
+            for out in _emit(pair):
+                yield out
+
+    def save(self, obj: Optional[Any] = None):
+        """
+        Finalize. If `obj` is provided, any (name, tensor) not already stored
+        via `store_early` will be added now (and may trigger final flushes).
+        """
+        if self.has_saved:
+            raise RuntimeError("have already saved")
+        if obj is not None:
+            for name, tensor in self._iter_named_tensors(obj):
+                self._writer.add(name, tensor)
+                self._committed_names.add(name)
+        self._writer.close()
+        self.has_saved = True
+
+    def __exit__(self, et, ev, tb):
+        # finalize if user forgot to call save()
+        if not self.has_saved:
+            self.save()

--- a/yalis/model.py
+++ b/yalis/model.py
@@ -1,6 +1,8 @@
 from yalis.external.config import Config
+import os
 from pathlib import Path
-from yalis.external.litgpt_utils import load_checkpoint, _EmptyInit
+from yalis.external.litgpt_utils import _EmptyInit, load_litgpt_checkpoint
+from yalis.model_loading import load_checkpoint_safetensors
 from yalis.external.model import GPT
 import torch.distributed as dist
 from yalis.attention.backends import AttentionBackend
@@ -44,7 +46,13 @@ def get_model(
         model = GPT(config).to(model_dtype)
 
     if not random_init:
-        checkpoint_path = checkpoint_dir / "lit_model.pth"
-        load_checkpoint(model, checkpoint_path)
+        checkpoint_path = checkpoint_dir / "yalis_checkpoints"
+        if os.path.exists(checkpoint_path):
+            load_checkpoint_safetensors(model, checkpoint_path)
+        else:
+            # Deprecated loading path as a fallback
+            checkpoint_path = checkpoint_dir / "lit_model.pth"
+            load_litgpt_checkpoint(model, checkpoint_path)
+
     model.eval()
     return model

--- a/yalis/model_loading.py
+++ b/yalis/model_loading.py
@@ -1,0 +1,255 @@
+import json
+from pathlib import Path
+from typing import Dict, Iterable, Tuple, Optional, Any
+from collections.abc import MutableMapping
+
+import torch
+import torch.nn as nn
+from safetensors import safe_open
+from yalis.utils import print_rank0
+from tqdm import tqdm
+
+
+class LazySafeTensorDict(MutableMapping):
+    """
+    Dict-like view over safetensors that:
+      - Enumerates all keys without loading tensors.
+      - Loads an individual tensor only when accessed (get/pop).
+      - Loads it on the device/dtype of the target param/buffer.
+
+    Supports:
+      - Single file: /cpt/model.safetensors
+      - Sharded: /cpt/model.safetensors.index.json + model-00001.safetensors,..
+    """
+
+    def __init__(
+        self,
+        ckpt_path: Path,
+        *,
+        name_to_device_dtype: Dict[str, Tuple[torch.device, torch.dtype]],
+    ) -> None:
+        self._root = Path(ckpt_path)
+        self._map: Dict[str, str] = (
+            {}
+        )  # name -> shard filename (or single file)
+        self._keys: Iterable[str] = []
+        self._single_file: Optional[Path] = None
+        self._opened: Dict[str, Any] = {}  # shard path -> safe_open handle
+        self._cache: Dict[str, torch.Tensor] = {}
+        self._name_to_devdtype = name_to_device_dtype
+
+        if self._root.is_file() and self._root.suffix == ".safetensors":
+            # Single-file checkpoint
+            self._single_file = self._root
+            with safe_open(
+                str(self._single_file), framework="pt", device="cpu"
+            ) as f:
+                self._keys = list(f.keys())
+            for k in self._keys:
+                self._map[k] = self._single_file.name
+        else:
+            # Sharded (expect an index json nearby)
+            index_json = None
+            if self._root.is_file() and self._root.name.endswith(
+                ".index.json"
+            ):
+                index_json = self._root
+                base_dir = self._root.parent
+            elif self._root.is_dir():
+                # look for *.safetensors.index.json
+                idxs = [p for p in self._root.glob("*.safetensors.index.json")]
+                if not idxs:
+                    raise FileNotFoundError(
+                        f"No *.safetensors.index.json in {self._root}"
+                    )
+                index_json = idxs[0]
+                base_dir = self._root
+            else:
+                raise FileNotFoundError(f"Checkpoint not found: {self._root}")
+
+            with open(index_json, "r") as f:
+                idx = json.load(f)
+            wm = idx.get("weight_map", {})
+            if not wm:
+                raise RuntimeError("Index JSON missing weight_map")
+
+            # Names may come like "model.xxx". Provide both aliases if needed.
+            self._map = dict(wm)
+            # Build key list and alias stripping 'model.' prefix if all have it
+            self._keys = list(self._map.keys())
+
+            # Make sure shard files exist
+            for shard in set(self._map.values()):
+                if not (base_dir / shard).is_file():
+                    raise FileNotFoundError(
+                        f"Shard missing: {base_dir / shard}"
+                    )
+
+            self._base_dir = base_dir
+
+        # If most keys are prefixed with "model.", support alias without it
+        if self._keys and all(k.startswith("model.") for k in self._keys):
+            extra = {k[6:]: self._map[k] for k in list(self._map.keys())}
+            self._map.update(extra)
+            self._keys = list(self._map.keys())
+
+    # ---- Minimal mapping API used by nn.Module._load_from_state_dict ----
+
+    def __contains__(self, key: object) -> bool:
+        return isinstance(key, str) and key in self._map
+
+    def __getitem__(self, key: str) -> torch.Tensor:
+        # Allow get without loading: but when asked,
+        # load into correct device/dtype
+        if key in self._cache:
+            return self._cache[key]
+        if key not in self._map:
+            raise KeyError(key)
+        t = self._load_key(key)
+        self._cache[key] = t
+        return t
+
+    def get(self, key: str, default=None):
+        return self[key] if key in self else default
+
+    def pop(self, key: str, default=None):
+        if key in self:
+            v = self[key]  # loads if needed
+            del self._map[key]
+            self._cache.pop(key, None)
+            return v
+        if default is not None:
+            return default
+        raise KeyError(key)
+
+    def keys(self):
+        return self._map.keys()
+
+    def __iter__(self):
+        return iter(self._map)
+
+    def __len__(self) -> int:
+        return len(self._map)
+
+    # We don’t support mutation into the checkpoint
+    def __setitem__(self, key, value):
+        raise NotImplementedError
+
+    def __delitem__(self, key):
+        # PyTorch won't call this directly; we implement pop above.
+        raise NotImplementedError
+
+    # ---- internals ----
+
+    def _open_handle(self, shard_file: str):
+        path = (
+            self._single_file
+            if self._single_file and self._single_file.name == shard_file
+            else (self._base_dir / shard_file)
+        )
+        spath = str(path)
+        if spath not in self._opened:
+            # Keep handle open to avoid re-parsing the header repeatedly
+            self._opened[spath] = safe_open(
+                spath, framework="pt", device="cpu"
+            )
+        return self._opened[spath]
+
+    def _load_key(self, name: str) -> torch.Tensor:
+        shard = self._map[name]
+        f = self._open_handle(shard)
+        # Load CPU tensor first
+        t = f.get_tensor(
+            name if name in f.keys() else f.keys().get(name, name)
+        )
+        # Move & cast to expected device/dtype if known
+        dev, dt = self._name_to_devdtype.get(name, (None, None))
+        if (
+            dev is None
+            and name.startswith("model.")
+            and name[6:] in self._name_to_devdtype
+        ):
+            dev, dt = self._name_to_devdtype[name[6:]]
+        if dt is not None and t.dtype != dt:
+            t = t.to(dtype=dt)
+        if dev is not None and t.device != dev:
+            # non-blocking move if CUDA target
+            non_blocking = dev.type == "cuda"
+            t = t.to(device=dev, non_blocking=non_blocking)
+        return t
+
+    def close(self):
+        for h in self._opened.values():
+            try:
+                h.close()
+            except Exception:
+                pass
+        self._opened.clear()
+
+
+def _collect_param_buffer_devdtype(
+    model: nn.Module,
+) -> Dict[str, Tuple[torch.device, torch.dtype]]:
+    """
+    Map each state_dict key -> (device, dtype) from the current model,
+    so we can load tensors directly onto the right device/dtype.
+    """
+    mapping = {}
+    for n, p in model.named_parameters(recurse=True):
+        dev = None if p.device.type == "meta" else p.device
+        mapping[n] = (dev, p.dtype)
+    for n, b in model.named_buffers(recurse=True):
+        dev = None if b.device.type == "meta" else b.device
+        mapping[n] = (dev, b.dtype)
+    return mapping
+
+
+def load_checkpoint_safetensors(
+    model: nn.Module,
+    checkpoint_path: Path,
+    *,
+    strict: bool = True,
+) -> None:
+    print_rank0(
+        f"Loading checkpoint (lazy safetensors) from {checkpoint_path}"
+    )
+
+    # Build per-key device/dtype targets from the CURRENT model
+    name_to_devdtype = _collect_param_buffer_devdtype(model)
+
+    # Build a lazy dict view over the safetensors checkpoint
+    lazy_sd = LazySafeTensorDict(
+        checkpoint_path, name_to_device_dtype=name_to_devdtype
+    )
+
+    # Progress hook (unchanged from your current code)
+    modules_to_hook = [
+        m
+        for m in model.modules()
+        if any(True for _ in m.parameters(recurse=False))
+        or any(True for _ in m.buffers(recurse=False))
+    ]
+    assert (
+        len(modules_to_hook) > 0
+    ), "Could not find modules with direct parameters or buffers"
+
+    pbar = tqdm(total=len(modules_to_hook), desc="Loading State Dict")
+
+    def _post_hook(module, incompatible_keys):
+        pbar.update(1)
+
+    hooks = [
+        m.register_load_state_dict_post_hook(_post_hook)
+        for m in modules_to_hook
+    ]
+
+    try:
+        model.load_state_dict(lazy_sd, strict=strict, assign=True)
+    except Exception as e:
+        print_rank0(f"Error loading checkpoint: {e}")
+        raise
+    finally:
+        for h in hooks:
+            h.remove()
+        pbar.close()
+        lazy_sd.close()

--- a/yalis/model_loading.py
+++ b/yalis/model_loading.py
@@ -159,9 +159,8 @@ class LazySafeTensorDict(MutableMapping):
         shard = self._map[name]
         f = self._open_handle(shard)
         # Load CPU tensor first
-        t = f.get_tensor(
-            name if name in f.keys() else f.keys().get(name, name)
-        )
+        t = f.get_tensor(name)
+
         # Move & cast to expected device/dtype if known
         dev, dt = self._name_to_devdtype.get(name, (None, None))
         if (
@@ -179,11 +178,6 @@ class LazySafeTensorDict(MutableMapping):
         return t
 
     def close(self):
-        for h in self._opened.values():
-            try:
-                h.close()
-            except Exception:
-                pass
         self._opened.clear()
 
 


### PR DESCRIPTION
This moves the checkpoint format used by Yalis from .pth to safetensors
The old .pth loading is still supported but deprecated
This improves model loading times by a substantial amount:

Loading 405B on 16 GPUs earlier:
```
Initializing Model took 926.077620267868 seconds
```

Now:
```
Initializing Model took 258.49044156074524 seconds
```