### PR TITLE
Checkpoint conversion fix and removed gc collect overhead

### DIFF
--- a/yalis/external/convert_hf_checkpoint.py
+++ b/yalis/external/convert_hf_checkpoint.py
@@ -213,7 +213,7 @@ def copy_weights_qwen_3(
         param = load_param(param, from_name, dtype, verbose=debug_mode)
 
         if to_name == "transformer.wte.weight":
-            transformer_wte_weight = param
+            transformer_wte_weight = param.clone().detach()
 
         if saver is not None:
             param = saver.store_early(to_name, param)
@@ -356,7 +356,7 @@ def copy_weights_qwen_2_5(
         param = load_param(param, from_name, dtype, verbose=debug_mode)
 
         if to_name == "transformer.wte.weight":
-            transformer_wte_weight = param
+            transformer_wte_weight = param.clone().detach()
 
         if saver is not None:
             param = saver.store_early(to_name, param)
@@ -580,7 +580,7 @@ def copy_weights_hf_llama(
         param = load_param(param, name, dtype, verbose=debug_mode)
 
         if to_name == "transformer.wte.weight":
-            transformer_wte_weight = param
+            transformer_wte_weight = param.clone().detach()
 
         if saver is not None:
             # For the tensors that have a to mapping, we use the same store early principle
@@ -719,7 +719,7 @@ def copy_weights_gemma_2(
             to_name = weight_map[name]
 
         if to_name == "transformer.wte.weight":
-            transformer_wte_weight = param
+            transformer_wte_weight = param.clone().detach()
 
         param = load_param(param, name, dtype)
         if saver is not None:

--- a/yalis/external/download.py
+++ b/yalis/external/download.py
@@ -24,7 +24,8 @@ def download_from_hub(
     tokenizer_only: bool = False,
     convert_checkpoint: bool = True,
     dtype: Optional[str] = None,
-    checkpoint_dir: Path = Path(os.getenv("YALIS_CACHE", "~/.cache/yalis")),
+    checkpoint_dir: Path = Path(os.getenv("YALIS_CACHE", "~/.cache/yalis"))
+    / "checkpoints",
     model_name: Optional[str] = None,
 ) -> None:
     """Download weights or tokenizer data from the Hugging Face Hub.

--- a/yalis/tensor_parallel/linear.py
+++ b/yalis/tensor_parallel/linear.py
@@ -101,9 +101,6 @@ def initialize_params(
     # placing outside leads to pytorch not deleting the reserved memory
     torch.cuda.empty_cache()
 
-    # This leads to immediate memory garbage collection but can be slow
-    # Probably not needed
-    gc.collect()
     return params
 
 

--- a/yalis/tensor_parallel/linear.py
+++ b/yalis/tensor_parallel/linear.py
@@ -22,7 +22,6 @@ from yalis.tensor_parallel.nvshmem_comm import (
 )
 
 from typing import Optional, Sequence
-import gc
 
 try:
     import torch.distributed._symmetric_memory as symm_mem


### PR DESCRIPTION
Was getting a parameter sharing error with new safetensors for larger models. This change fixes that. Tested with Llama 70B. Also removes gc collect after every parameter leading to slightly better loading times (especially on fewer gpus)